### PR TITLE
Related to issue #99. Error after login because samples has null value

### DIFF
--- a/relecov_core/utils/handling_samples.py
+++ b/relecov_core/utils/handling_samples.py
@@ -486,7 +486,10 @@ def get_sample_per_date_per_all_lab(detailed=None):
             .order_by("sequencing_date")
         )
         for s_date in s_dates:
-            date = datetime.strftime(s_date, "%d-%B-%Y")
+            try:
+                date = datetime.strftime(s_date, "%d-%B-%Y")
+            except ValueError:
+                continue
             all_samples_per_date[date] = Sample.objects.filter(
                 sequencing_date=s_date
             ).count()


### PR DESCRIPTION
Related to issue #99. 
Fixing error after login in relecov platform, because samples has null value in sequencing_date, and error page is showed when trying to convert None to date format