### PR TITLE
Fixes for apache logs and missing dates

### DIFF
--- a/conf/relecov_apache_centos_redhat.conf
+++ b/conf/relecov_apache_centos_redhat.conf
@@ -39,7 +39,8 @@
         Allow from all
     </Directory>
 
-    ErrorLog logs/relecov-platform/relecov-platform.isciiides.es-apache.error.log
-    CustomLog logs/relecov-platform/relecov-platform.isciiides.es-apache.access.log combined
+    ErrorLog logs/relecov-platform.isciiides.es-apache.error.log
+    CustomLog logs/relecov-platform.isciiides.es-apache.access.log combined env=!forwarded
+    CustomLog logs/relecov-platform.isciiides.es-apache.access.log proxy env=forwarded
 
 </VirtualHost>

--- a/conf/relecov_apache_ubuntu.conf
+++ b/conf/relecov_apache_ubuntu.conf
@@ -39,7 +39,8 @@
         Allow from all
     </Directory>
 
-    ErrorLog logs/relecov-platform/relecov-platform.isciiides.es-apache.error.log
-    CustomLog logs/relecov-platform/relecov-platform.isciiides.es-apache.access.log combined
+    ErrorLog logs/relecov-platform.isciiides.es-apache.error.log
+    CustomLog logs/relecov-platform.isciiides.es-apache.access.log combined env=!forwarded
+    CustomLog logs/relecov-platform.isciiides.es-apache.access.log proxy env=forwarded
 
 </VirtualHost>

--- a/relecov_core/utils/samples.py
+++ b/relecov_core/utils/samples.py
@@ -664,6 +664,8 @@ def get_all_recieved_samples_with_dates(accumulated=False):
     )
     sum = 0
     for date in dates:
+        if date[0] is None:
+            continue
         value = relecov_core.models.Sample.objects.filter(
             sequencing_date__contains=date[0]
         ).count()

--- a/relecov_core/views.py
+++ b/relecov_core/views.py
@@ -545,17 +545,17 @@ def received_samples(request):
 
     # # collecting now data from database
     sample_data["received_samples_graph"] = (
-        relecov_core.utils.samples_graphics.display_received_samples_graph()
+        relecov_core.utils.samples_graphics.received_samples_graph()
     )
     # Pie charts
     # data = parse_json_file()
     # create_samples_received_over_time_per_ccaa_pieChart(data)
     sample_data["samples_per_ccaa"] = (
-        relecov_core.utils.samples_graphics.display_received_per_ccaa()
+        relecov_core.utils.samples_graphics.received_per_ccaa()
     )
     # create_samples_received_over_time_per_laboratory_pieChart(data)
     sample_data["samples_per_lab"] = (
-        relecov_core.utils.samples_graphics.display_received_per_lab()
+        relecov_core.utils.samples_graphics.received_per_lab()
     )
     return render(
         request,


### PR DESCRIPTION
This PR addresses an error during server run due to apache logs being saved in a wrong location. It also fixes an error with graphics in received samples (intranet) when a sample had a missing date, which is now skipped instead. Finally a small refactor update was introduced.