### PR TITLE
Renamed fields for API's variantdata requests

### DIFF
--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -67,8 +67,8 @@ def get_variant_id(data):
         return {"ERROR": core.config.ERROR_CHROMOSOME_NOT_DEFINED_IN_DATABASE}
     variant_obj = core.models.Variant.objects.filter(
         chromosomeID_id=chr_obj,
-        pos__iexact=data["Variant"]["pos"],
-        alt__iexact=data["Variant"]["alt"],
+        pos__iexact=data["pos"],
+        alt__iexact=data["alt"],
     ).last()
     if variant_obj is None:
         # Create the variant
@@ -78,9 +78,9 @@ def get_variant_id(data):
         variant_dict = {}
         variant_dict["chromosomeID_id"] = chr_obj.get_chromosome_id()
         variant_dict["filterID_id"] = filter_obj.get_filter_id()
-        variant_dict["pos"] = data["Variant"]["pos"]
-        variant_dict["alt"] = data["Variant"]["alt"]
-        variant_dict["ref"] = data["Variant"]["ref"]
+        variant_dict["pos"] = data["pos"]
+        variant_dict["alt"] = data["alt"]
+        variant_dict["ref"] = data["ref"]
         variant_serializer = core.api.serializers.CreateVariantSerializer(
             data=variant_dict
         )
@@ -104,7 +104,7 @@ def get_required_variant_ann_id(data):
     if gene_obj is None:
         return {"ERROR": core.config.ERROR_GENE_NOT_DEFINED_IN_DATABASE}
     v_ann_ids["geneID_id"] = gene_obj.get_gene_id()
-    effect_obj = create_or_get_effect_obj(data["Effect"])
+    effect_obj = create_or_get_effect_obj(data["effect"])
     if isinstance(effect_obj, dict):
         return effect_obj
     v_ann_ids["geneID_id"] = gene_obj.get_gene_id()
@@ -122,6 +122,8 @@ def split_variant_data(data, sample_obj, date):
     split_data["variant_in_sample"]["variantID_id"] = variant_id
     split_data["variant_in_sample"]["analysis_date"] = date
 
+    var_keys = ["dp", "ref_dp", "alt_dp", "af"]
+    data["VariantInSample"] = {x:y for x,y in data.items() if x in var_keys}
     split_data["variant_in_sample"].update(data["VariantInSample"])
 
     v_ann_id = get_required_variant_ann_id(data)
@@ -129,7 +131,9 @@ def split_variant_data(data, sample_obj, date):
         return v_ann_id
     split_data["variant_ann"] = v_ann_id
     split_data["variant_ann"]["variantID_id"] = variant_id
-
+    
+    annot_keys = ["hgvs_c", "hgvs_p", "hgvs_p_1_letter"]
+    data["VariantAnnotation"] = {x:y for x,y in data.items() if x in annot_keys}
     split_data["variant_ann"].update(data["VariantAnnotation"])
     return split_data
 

--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -123,7 +123,7 @@ def split_variant_data(data, sample_obj, date):
     split_data["variant_in_sample"]["analysis_date"] = date
 
     var_keys = ["dp", "ref_dp", "alt_dp", "af"]
-    data["VariantInSample"] = {x:y for x,y in data.items() if x in var_keys}
+    data["VariantInSample"] = {x: y for x, y in data.items() if x in var_keys}
     split_data["variant_in_sample"].update(data["VariantInSample"])
 
     v_ann_id = get_required_variant_ann_id(data)
@@ -131,9 +131,9 @@ def split_variant_data(data, sample_obj, date):
         return v_ann_id
     split_data["variant_ann"] = v_ann_id
     split_data["variant_ann"]["variantID_id"] = variant_id
-    
+
     annot_keys = ["hgvs_c", "hgvs_p", "hgvs_p_1_letter"]
-    data["VariantAnnotation"] = {x:y for x,y in data.items() if x in annot_keys}
+    data["VariantAnnotation"] = {x: y for x, y in data.items() if x in annot_keys}
     split_data["variant_ann"].update(data["VariantAnnotation"])
     return split_data
 

--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -10,7 +10,7 @@ def create_or_get_filter_obj(filter_value):
     if core.models.Filter.objects.filter(filter__iexact=filter_value).exists():
         return core.models.Filter.objects.filter(filter__iexact=filter_value).last()
     filter_serializer = core.api.serializers.CreateFilterSerializer(
-        data={"filter": filter_value}
+        data={"Filter": filter_value}
     )
     if filter_serializer.is_valid():
         filter_obj = filter_serializer.save()
@@ -72,7 +72,7 @@ def get_variant_id(data):
     ).last()
     if variant_obj is None:
         # Create the variant
-        filter_obj = create_or_get_filter_obj(data["filter"])
+        filter_obj = create_or_get_filter_obj(data["Filter"])
         if isinstance(filter_obj, dict):
             return filter_obj
         variant_dict = {}

--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -62,7 +62,7 @@ def store_variant_in_sample(v_data):
 
 def get_variant_id(data):
     """look out for the necessary reference ids to create the variance instance"""
-    chr_obj = core.utils.variants.get_if_chromosomes_exists(data["Chromosome"])
+    chr_obj = core.utils.variants.get_if_chromosomes_exists(data["chromosome"])
     if chr_obj is None:
         return {"ERROR": core.config.ERROR_CHROMOSOME_NOT_DEFINED_IN_DATABASE}
     variant_obj = core.models.Variant.objects.filter(
@@ -72,7 +72,7 @@ def get_variant_id(data):
     ).last()
     if variant_obj is None:
         # Create the variant
-        filter_obj = create_or_get_filter_obj(data["Filter"])
+        filter_obj = create_or_get_filter_obj(data["filter"])
         if isinstance(filter_obj, dict):
             return filter_obj
         variant_dict = {}
@@ -99,7 +99,7 @@ def get_variant_analysis_defined(s_obj):
 def get_required_variant_ann_id(data):
     """Look for the ids that variant annotation needs"""
     v_ann_ids = {}
-    gene_obj = core.utils.variants.get_gene_obj_from_gene_name(data["Gene"])
+    gene_obj = core.utils.variants.get_gene_obj_from_gene_name(data["gene"])
 
     if gene_obj is None:
         return {"ERROR": core.config.ERROR_GENE_NOT_DEFINED_IN_DATABASE}

--- a/core/views.py
+++ b/core/views.py
@@ -258,6 +258,8 @@ def intranet(request):
                 intra_data["ena_graph"] = core.utils.public_db.percentage_graphic(
                     len(sample_lab_objs), len(ena_acc), ""
                 )
+        else:
+            intra_data = f"No samples found for selected laboratory: {lab_name}"
         return render(request, "core/intranet.html", {"intra_data": intra_data})
     else:
         # loged user belongs to Relecov Manager group

--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -52,7 +52,7 @@ def create_lineages_variations_graphic(date_range=None):
                             {"label": "Last 6 months", "value": "180"},
                             {"label": "Last 3 months", "value": "90"},
                             {"label": "Last month", "value": "30"},
-                            {"label": "Last week", "value": "7"}
+                            {"label": "Last week", "value": "7"},
                         ],
                     ),
                 ],

--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -46,9 +46,13 @@ def create_lineages_variations_graphic(date_range=None):
                         id="periodTime",
                         options=[
                             {"label": "Select Period", "value": ""},
+                            {"label": "Last 4 years", "value": "1460"},
                             {"label": "Last 2 years", "value": "730"},
+                            {"label": "Last year", "value": "365"},
                             {"label": "Last 6 months", "value": "180"},
+                            {"label": "Last 3 months", "value": "90"},
                             {"label": "Last month", "value": "30"},
+                            {"label": "Last week", "value": "7"}
                         ],
                     ),
                 ],


### PR DESCRIPTION
As per the title, this PR includes some field renaming that was leading to errors when trying to update variant data through API requests. This change had to be done because the input file (long_table.json) was reformatted and could not be parsed the same way as before.