### PR TITLE
Fix schemahandling upload

### DIFF
--- a/conf/template_settings.py
+++ b/conf/template_settings.py
@@ -161,7 +161,7 @@ SWAGGER_SETTINGS = {"SECURITY_DEFINITIONS": {"basic": {"type": "basic"}}}
 
 #  Media settings
 MEDIA_URL = "/documents/"
-MEDIA_ROOT = os.path.join(BASE_DIR, "documents/")
+MEDIA_ROOT = "documents/"
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/

--- a/core/utils/generic_functions.py
+++ b/core/utils/generic_functions.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime
 from django.core.files.storage import FileSystemStorage
 from django.contrib.auth.models import User
-from django.conf import settings
 
 # local imports
 import core.models

--- a/core/utils/generic_functions.py
+++ b/core/utils/generic_functions.py
@@ -56,11 +56,10 @@ def store_file(user_file, folder):
     """
     filename, file_extension = os.path.splitext(user_file.name)
     file_name = filename + "_" + str(time.strftime("%Y%m%d-%H%M%S")) + file_extension
-    path_file = os.path.join(folder, file_name)
-    saved_file = os.path.join(settings.MEDIA_ROOT, path_file)
+    store_filepath = os.path.join(folder, file_name)
     fs = FileSystemStorage()
-    fs.save(saved_file, user_file)
-    return path_file
+    fs.save(store_filepath, user_file)
+    return store_filepath
 
 
 def check_valid_date_format(date):

--- a/core/utils/metadata_json.py
+++ b/core/utils/metadata_json.py
@@ -53,7 +53,7 @@ def load_metadata_json(json_file):
     except json.decoder.JSONDecodeError:
         return {"ERROR": core.config.ERROR_INVALID_JSON}
     data["file_name"] = core.utils.generic_functions.store_file(
-        json_file, core.config.METADATA_JSON_UPLOAD_FOLDER
+        json_file, core.config.SCHEMAS_UPLOAD_FOLDER
     )
     return data
 


### PR DESCRIPTION
## PR description

This PR fixes the `SuspiciousFileOperation` error that occurs in specific DJANGO version when uploading a schema file to the relecov-platform due to the presence of a global path pattern ("/") in the media directory (documents).

```
raise SuspiciousFileOperation(
django.core.exceptions.SuspiciousFileOperation: Detected path traversal attempt in 'path/to/relecov_schema_DATE.json'
```

Source: https://forum.djangoproject.com/t/django-3-2-4-update-suspiciousfileoperation-detected-path-traversal-attempt/8196/3

Session info:
```
Python 3.12.4
Django 4.2.15
```
