### PR TITLE
fixed admin user profile error

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -29,7 +29,6 @@ class Profile(models.Model):
 
 @receiver(post_save, sender=User)
 def create_or_update_user_profile(sender, instance, created, **kwargs):
-    # Source: https://stackoverflow.com/questions/52244032/i-keep-getting-relatedobjectdoesnotexist-at-admin-login-how-do-i-successfully
     try:
         instance.profile.save()
     except ObjectDoesNotExist:

--- a/core/models.py
+++ b/core/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.core.exceptions import ObjectDoesNotExist
 
 # Local imports
 import core.config
@@ -28,9 +29,11 @@ class Profile(models.Model):
 
 @receiver(post_save, sender=User)
 def create_or_update_user_profile(sender, instance, created, **kwargs):
-    if created:
+    # Source: https://stackoverflow.com/questions/52244032/i-keep-getting-relatedobjectdoesnotexist-at-admin-login-how-do-i-successfully
+    try:
+        instance.profile.save()
+    except ObjectDoesNotExist:
         Profile.objects.create(user=instance)
-    instance.profile.save()
 
 
 class BioinfoMetadataFile(models.Model):


### PR DESCRIPTION
## PR description

This PR enables the creation of a user profile if one does not already exist. Currently, if a user lacks an associated profile, an error occurs at the line instance.profile.save() in the code. This  checks  for an existing profile and creating one if it is missing.


Source: https://stackoverflow.com/questions/52244032/i-keep-getting-relatedobjectdoesnotexist-at-admin-login-how-do-i-successfully