### PR TITLE
Replace deprecated pkg_resources in favour of setuptools

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -21,3 +21,4 @@ django-markdownx==4.0.7
 relecov-tools
 dash-daq==0.5.0
 numpy==2.1.0
+setuptools==75.2.0


### PR DESCRIPTION
## PR description

This PR updates requirements recepie. Details:
- `pkg_resources` have been moved to `setuptools` in `python 3.12` (https://docs.python.org/3/whatsnew/3.12.html).
