### PR TITLE
Python linting returns true if no .py files in PR

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -2,11 +2,10 @@ name: python_lint
 
 on:
   push:
-    paths:
-      - '**.py'
+    branches: "**"
   pull_request:
-    paths:
-      - '**.py'
+    types: [opened, reopened, synchronize, closed]
+    branches: "**"
 
 jobs:
   flake8_py3:
@@ -18,18 +17,43 @@ jobs:
           python-version: 3.9.x
           architecture: x64
       - name: Checkout PyTorch
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install flake8
         run: pip install flake8
+      - name: Check for Python file changes
+        id: file_check
+        uses: tj-actions/changed-files@v44
+        with:
+          sha: ${{ github.event.pull_request.head.sha }}
+          files: |
+             **.py
       - name: Run flake8
+        if: steps.file_check.outputs.any_changed == 'true'
         run: flake8 --ignore E501,W503,E203,W605
+      - name: No Python files changed
+        if: steps.file_check.outputs.any_changed != 'true'
+        run: echo "No Python files have been changed."
 
   black_lint:
     runs-on: ubuntu-latest
     steps:
         - name: Setup
           uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
         - name: Install black in jupyter
           run: pip install black[jupyter]
+        - name: Check for Python file changes
+          id: file_check
+          uses: tj-actions/changed-files@v44
+          with:
+            sha: ${{ github.event.pull_request.head.sha }}
+            files: '**.py'
         - name: Check code lints with Black
+          if: steps.file_check.outputs.any_changed == 'true'
           uses: psf/black@stable
+        - name: No Python files changed
+          if: steps.file_check.outputs.any_changed != 'true'
+          run: echo "No Python files have been changed."


### PR DESCRIPTION
With these changes python linting workflows won't stay on hold forever when no .py files are included in the PR