### PR TITLE
Set user's schema input as default

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -67,6 +67,24 @@ class SchemaManager(models.Manager):
             schema_in_use=True,
             schema_apps_name=data["schema_app_name"],
         )
+        # Check if schema default is available
+        if new_schema.schema_default:
+            self.filter(schema_apps_name=new_schema.schema_apps_name).exclude(
+                id=new_schema.id
+            ).update(schema_default=False)
+
+        # If not schema default selected, then use the last loaded schema
+        if not self.filter(
+            schema_default=True, schema_apps_name=new_schema.schema_apps_name
+        ).exists():
+            last_schema = (
+                self.filter(schema_apps_name=new_schema.schema_apps_name)
+                .order_by("-generated_at")
+                .first()
+            )
+            if last_schema:
+                last_schema.schema_default = True
+                last_schema.save()
         return new_schema
 
 

--- a/core/templates/core/schemaHandling.html
+++ b/core/templates/core/schemaHandling.html
@@ -61,7 +61,7 @@
                                                     <br>
                                                     <div class="col-md-12 form-check form-switch">
                                                         <label class="form-check-label" for="schemaDefault">Default schema</label>
-                                                        <input class="form-check-input" type="checkbox" id="schemaDefault" name="schemaDefault">
+                                                        <input class="form-check-input" type="checkbox" id="schemaDefault" name="schemaDefault" checked>
                                                     </div>
                                                     <div hidden class="spinner-border text-success" role="status" id="spinner">
                                                         <span class="visually-hidden">Loading...</span>


### PR DESCRIPTION
Mark the user's schema input as selected by default. Users can manually uncheck it if needed.



Closes #225 




