### PR TITLE
Corrected bio_f_values calculation and schema filtering

### DIFF
--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -69,7 +69,7 @@ def get_bioinfo_analyis_fields_utilization(schema_obj=None):
     if not b_field_objs.exists():
         return b_data
 
-    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(schema_obj.id)
+    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(schema_obj)
     if num_samples_in_sch == 0:
         return b_data
     b_data = {

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -88,7 +88,7 @@ def get_bioinfo_analyis_fields_utilization(schema_obj=None):
             b_data["fields_value"][f_name] = 0
             continue
         # b_data[schema_name][f_name] = [count]
-        count_not_empty = b_field_obj_info.exclude(value__in=["None", ""]).count()
+        count_not_empty = b_field_obj_info.exclude(value__in=["None", "Not Provided", ""]).count()
         b_data["fields_value"][f_name] = count_not_empty
         if count_not_empty == 0:
             b_data["always_none"].append(f_name)

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -69,9 +69,7 @@ def get_bioinfo_analyis_fields_utilization(schema_obj=None):
     if not b_field_objs.exists():
         return b_data
 
-    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(
-        schema_obj.get_schema_name()
-    )
+    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(schema_obj.id)
     if num_samples_in_sch == 0:
         return b_data
     b_data = {

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -88,7 +88,9 @@ def get_bioinfo_analyis_fields_utilization(schema_obj=None):
             b_data["fields_value"][f_name] = 0
             continue
         # b_data[schema_name][f_name] = [count]
-        count_not_empty = b_field_obj_info.exclude(value__in=["None", "Not Provided", ""]).count()
+        count_not_empty = b_field_obj_info.exclude(
+            value__in=["None", "Not Provided", ""]
+        ).count()
         b_data["fields_value"][f_name] = count_not_empty
         if count_not_empty == 0:
             b_data["always_none"].append(f_name)

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -476,9 +476,7 @@ def get_sample_obj_from_id(sample_id):
 
 def get_samples_count_per_schema(schema_id):
     """Get the number of samples that are stored in the schema"""
-    return core.models.Sample.objects.filter(
-        schema_obj__id=schema_id
-    ).count()
+    return core.models.Sample.objects.filter(schema_obj__id=schema_id).count()
 
 
 def get_sample_per_date_per_all_lab(detailed=None):

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -474,9 +474,9 @@ def get_sample_obj_from_id(sample_id):
     return None
 
 
-def get_samples_count_per_schema(schema_id):
+def get_samples_count_per_schema(schema_obj):
     """Get the number of samples that are stored in the schema"""
-    return core.models.Sample.objects.filter(schema_obj__id=schema_id).count()
+    return core.models.Sample.objects.filter(schema_obj=schema_obj).count()
 
 
 def get_sample_per_date_per_all_lab(detailed=None):

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -477,7 +477,7 @@ def get_sample_obj_from_id(sample_id):
 def get_samples_count_per_schema(schema_id):
     """Get the number of samples that are stored in the schema"""
     return core.models.Sample.objects.filter(
-        schema_obj__schema_name__iexact=schema_id
+        schema_obj__id=schema_id
     ).count()
 
 

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -474,10 +474,10 @@ def get_sample_obj_from_id(sample_id):
     return None
 
 
-def get_samples_count_per_schema(schema_name):
+def get_samples_count_per_schema(schema_id):
     """Get the number of samples that are stored in the schema"""
     return core.models.Sample.objects.filter(
-        schema_obj__schema_name__iexact=schema_name
+        schema_obj__schema_name__iexact=schema_id
     ).count()
 
 

--- a/dashboard/templates/dashboard/methodologyIndex.html
+++ b/dashboard/templates/dashboard/methodologyIndex.html
@@ -68,11 +68,11 @@
                             {% endif %}
                             <div class="row p-4" style="text-align: center;">
                                 {% if graphics.grouped_fields %}
-                                    <div class="col-sm-4">
+                                    <div class="col-lg-4 col-md-6 col-sm-12">
                                         {{graphics.grouped_fields | safe }}
                                     </div> <!-- end col -->
                                 {% endif %}
-                                <div class="col-sm-4">
+                                <div class="col-lg-4 col-md-6 col-sm-12">
                                     {% if graphics.ERROR %}
                                         <div class="card-body  text-center text-danger">
                                             <p>Completed fields in metadata </p>
@@ -82,7 +82,7 @@
                                         {% plotly_app name="lims_filled_values" ratio=1.2 %}
                                     {% endif %}
                                 </div> <!-- end col -->
-                                <div class="col-sm-4">
+                                <div class="col-lg-4 col-md-6 col-sm-12">
                                     {% if graphics.ERROR_ANALYSIS %}
                                         <div class="card-body  text-center text-danger">
                                             <br>

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -59,14 +59,8 @@ def schema_fields_utilization():
     if not bool(bio_fields):
         util_data["ERROR_ANALYSIS"] = "Not Data to process"
         return util_data
-
-    #f_values = []
-    #for value in bio_fields["fields_norm"].values():
-    #    f_values.append(value)
-    #if len(f_values) > 1:
-    #    util_data["bio_f_values"] = float("%.1f" % (mean(f_values) * 100))
-    #else:
-    #    util_data["bio_f_values"] = 0
+    
+    # Calculate bio_f_values
     num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(schema_obj.get_schema_name())
     num_fields = len(bio_fields["fields_value"])
     total_filled_values = sum(bio_fields["fields_value"].values())

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -4,6 +4,7 @@ from statistics import mean
 # Local imports
 import core.utils.bioinfo_analysis
 import core.utils.rest_api
+import core.utils.samples
 import core.utils.schema
 import dashboard.dashboard_config
 import dashboard.utils.plotly
@@ -59,13 +60,20 @@ def schema_fields_utilization():
         util_data["ERROR_ANALYSIS"] = "Not Data to process"
         return util_data
 
-    f_values = []
-    for value in bio_fields["fields_norm"].values():
-        f_values.append(value)
-    if len(f_values) > 1:
-        util_data["bio_f_values"] = float("%.1f" % (mean(f_values) * 100))
-    else:
-        util_data["bio_f_values"] = 0
+    #f_values = []
+    #for value in bio_fields["fields_norm"].values():
+    #    f_values.append(value)
+    #if len(f_values) > 1:
+    #    util_data["bio_f_values"] = float("%.1f" % (mean(f_values) * 100))
+    #else:
+    #    util_data["bio_f_values"] = 0
+    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(schema_obj.get_schema_name())
+    num_fields = len(bio_fields["fields_value"])
+    total_filled_values = sum(bio_fields["fields_value"].values())
+    total_possible_values = num_fields * num_samples_in_sch 
+    bio_f_values = (total_filled_values / total_possible_values) * 100 if total_possible_values > 0 else 0
+    util_data["bio_f_values"] = float("%.1f" % bio_f_values)
+    
     # Calculate empty fields and total fields for bio analysis fields
     empty_fields = len(bio_fields["always_none"]) + len(bio_fields["never_used"])
     total_fields = len(bio_fields["fields_norm"]) + empty_fields

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -61,9 +61,7 @@ def schema_fields_utilization():
         return util_data
 
     # Calculate bio_f_values
-    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(
-        schema_obj.get_schema_name()
-    )
+    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(schema_obj.id)
     num_fields = len(bio_fields["fields_value"])
     total_filled_values = sum(bio_fields["fields_value"].values())
     total_possible_values = num_fields * num_samples_in_sch

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -113,7 +113,7 @@ def index_dash_fields():
         dashboard.utils.plotly.graph_gauge_percent_values(
             app_name="lims_filled_values",
             value=util_data["lims_f_values"],
-            label="Lab filled values %",
+            label="Lab filled values",
         )
         # ##### Create comparison graphics #######
         if "ERROR_ANALYSIS" in util_data:
@@ -138,7 +138,7 @@ def index_dash_fields():
         dashboard.utils.plotly.graph_gauge_percent_values(
             app_name="bio_filled_values",
             value=util_data["bio_f_values"],
-            label="Bio filled values %",
+            label="Bio filled values",
             size=150,
         )
         # ##### create bar graph with all fields and values

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -59,15 +59,21 @@ def schema_fields_utilization():
     if not bool(bio_fields):
         util_data["ERROR_ANALYSIS"] = "Not Data to process"
         return util_data
-    
+
     # Calculate bio_f_values
-    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(schema_obj.get_schema_name())
+    num_samples_in_sch = core.utils.samples.get_samples_count_per_schema(
+        schema_obj.get_schema_name()
+    )
     num_fields = len(bio_fields["fields_value"])
     total_filled_values = sum(bio_fields["fields_value"].values())
-    total_possible_values = num_fields * num_samples_in_sch 
-    bio_f_values = (total_filled_values / total_possible_values) * 100 if total_possible_values > 0 else 0
+    total_possible_values = num_fields * num_samples_in_sch
+    bio_f_values = (
+        (total_filled_values / total_possible_values) * 100
+        if total_possible_values > 0
+        else 0
+    )
     util_data["bio_f_values"] = float("%.1f" % bio_f_values)
-    
+
     # Calculate empty fields and total fields for bio analysis fields
     empty_fields = len(bio_fields["always_none"]) + len(bio_fields["never_used"])
     total_fields = len(bio_fields["fields_norm"]) + empty_fields

--- a/dashboard/utils/plotly.py
+++ b/dashboard/utils/plotly.py
@@ -2,7 +2,7 @@
 import dash_bootstrap_components as dbc
 import dash_daq as daq
 import plotly.graph_objects as go
-from dash import html
+from dash import html, dcc
 from django_plotly_dash import DjangoDash
 from plotly.offline import plot
 
@@ -11,30 +11,24 @@ def graph_gauge_percent_values(app_name, value, label, size=180):
     """Create Dashboard application for showing a gauge graphic for the
     percentage  values
     """
-    app = DjangoDash(app_name, external_stylesheets=[dbc.themes.BOOTSTRAP])
-    if value <= 40:
-        text_color = "red"
-    elif value <= 75:
-        text_color = "#e6e600"
-    else:
-        text_color = "green"
-    app.layout = html.Div(
-        daq.Gauge(
-            showCurrentValue=True,
-            color={
-                "default": text_color,
-                "gradient": True,
-                "ranges": {"red": [0, 40], "yellow": [40, 80], "green": [80, 100]},
-            },
-            id="my-gauge-1",
-            label={"label": label, "style": {"font-size": "1.40rem", "color": "green"}},
-            labelPosition="bottom",
+    app = DjangoDash(app_name, external_stylesheets=[dbc.themes.BOOTSTRAP])    
+    graph = go.Figure(
+        go.Indicator(
+            mode="gauge+number",
             value=value,
-            max=100,
-            min=0,
-            size=size,
-        ),
+            number={"suffix": "%"},
+            domain={"x": [0, 1], "y": [0, 1]},
+            title={"text": label},
+            gauge={"axis": {"range": [None, 100]}},
+        )
     )
+    graph.update_layout(margin=dict(t=10, b=0, l=30, r=30),
+                        height=250)
+    
+    app.layout = html.Div([
+        dcc.Graph(figure=graph, config={"displayModeBar": False},
+                  style={"width": "100%", "height": "250px"}),
+    ], style={"width": "100%", "height": "250px"})
 
 
 def graph_gauge_value(app_name, value, label, size=180, color="#33bbff"):

--- a/dashboard/utils/plotly.py
+++ b/dashboard/utils/plotly.py
@@ -11,7 +11,7 @@ def graph_gauge_percent_values(app_name, value, label, size=180):
     """Create Dashboard application for showing a gauge graphic for the
     percentage  values
     """
-    app = DjangoDash(app_name, external_stylesheets=[dbc.themes.BOOTSTRAP])    
+    app = DjangoDash(app_name, external_stylesheets=[dbc.themes.BOOTSTRAP])
     graph = go.Figure(
         go.Indicator(
             mode="gauge+number",
@@ -22,13 +22,18 @@ def graph_gauge_percent_values(app_name, value, label, size=180):
             gauge={"axis": {"range": [None, 100]}},
         )
     )
-    graph.update_layout(margin=dict(t=10, b=0, l=30, r=30),
-                        height=250)
-    
-    app.layout = html.Div([
-        dcc.Graph(figure=graph, config={"displayModeBar": False},
-                  style={"width": "100%", "height": "250px"}),
-    ], style={"width": "100%", "height": "250px"})
+    graph.update_layout(margin=dict(t=10, b=0, l=30, r=30), height=250)
+
+    app.layout = html.Div(
+        [
+            dcc.Graph(
+                figure=graph,
+                config={"displayModeBar": False},
+                style={"width": "100%", "height": "250px"},
+            ),
+        ],
+        style={"width": "100%", "height": "250px"},
+    )
 
 
 def graph_gauge_value(app_name, value, label, size=180, color="#33bbff"):


### PR DESCRIPTION
This PR addresses [Issue #194](https://github.com/BU-ISCIII/relecov-platform/issues/194), which pointed out an incorrect calculation of the bio_f_values percentage in the methodology dashboard.

##  Issues related: 

Closes [#193](https://github.com/BU-ISCIII/relecov-platform/issues/193)  
Closes [#194](https://github.com/BU-ISCIII/relecov-platform/issues/194)  

## Changes

- Fixed schema filtering: Now correctly selects fields associated with the current schema using schema_id, preventing duplicate calculations when schema names are identical.

- Updated bio_f_values calculation: Previously, the percentage was based on fields that had at least one sample filled, leading to an overestimated value. Now, it is calculated as:
(total filled values) / (total possible values) * 100

- Replaced old **dash_daq** gauge plots with **Plotly go.Indicator**.  

- Improved **styling** and **responsiveness** for better dashboard visualization. 
 
- Adjusted **titles and formatting** for consistency.  


