### PR TITLE
Stop returning None when Json_data is empty

### DIFF
--- a/core/templates/core/intranet.html
+++ b/core/templates/core/intranet.html
@@ -287,7 +287,9 @@
                                                             <div class="col-md-5">
                                                                     {{ intra_data.sample_gauge_graph | safe }}
                                                             </div> <!-- end col-md-5 -->
-
+                                                            <div class="col-md-12">
+                                                                {% plotly_app name="samplePerLabGraphic" ratio=1 %}
+                                                        </div> <!-- end col-md-7 -->
                                                         {% else %}
                                                             <div class="col-md-7">
                                                                 <div class="card border-warning mb-3">

--- a/dashboard/utils/generic_graphic_data.py
+++ b/dashboard/utils/generic_graphic_data.py
@@ -36,8 +36,5 @@ def get_graphic_json_data(graphic_name):
             .last()
             .get_json_data()
         )
-        if not json_data:
-            return None
-        else:
-            return json_data
+        return json_data
     return None


### PR DESCRIPTION
As per the title, when json_data existed but was empty (`e.g. json_data = {}`) get_graphic_json_data() returned None, which was prone to errors as its not the expected datatype.

This PR fixes that problem by always returning json_data if it exists in GraphicJson model.

Also included the select-lab plot for non-admin users in intranet.html template as it was missing from a previous PR