### PR TITLE
Fixed Received Samples per Laboratory Center plot

### DIFF
--- a/core/utils/samples_graphics.py
+++ b/core/utils/samples_graphics.py
@@ -3,7 +3,7 @@ import core.utils.plotly_graphics
 import core.utils.rest_api
 import core.utils.samples
 import dashboard.utils.generic_process_data
-
+import dashboard.utils.plotly
 
 def received_per_ccaa():
     """Fetch the data from LIMS and show them in a graphic bar"""
@@ -44,12 +44,13 @@ def received_per_lab():
         samples_per_lab = dashboard.utils.generic_graphic_data.get_graphic_json_data(
             "samples_received_per_lab"
         )
-    return core.utils.plotly_graphics.bar_graphic(
+    return dashboard.utils.plotly.bar_graphic(
         data=samples_per_lab,
         col_names=["x", "y"],
         legend=[""],
         yaxis={"title": "Number of samples"},
-        options={"title": "", "height": 400, "colors": "#1aff8c"},
+        options={"title": "", "height": 400, "colors": "#1aff8c",
+                 "truncate_labels": 15},
     )
 
 

--- a/core/utils/samples_graphics.py
+++ b/core/utils/samples_graphics.py
@@ -5,6 +5,7 @@ import core.utils.samples
 import dashboard.utils.generic_process_data
 import dashboard.utils.plotly
 
+
 def received_per_ccaa():
     """Fetch the data from LIMS and show them in a graphic bar"""
     samples_per_ccaa = dashboard.utils.generic_graphic_data.get_graphic_json_data(
@@ -49,8 +50,12 @@ def received_per_lab():
         col_names=["x", "y"],
         legend=[""],
         yaxis={"title": "Number of samples"},
-        options={"title": "", "height": 400, "colors": "#1aff8c",
-                 "truncate_labels": 15},
+        options={
+            "title": "",
+            "height": 400,
+            "colors": "#1aff8c",
+            "truncate_labels": 15,
+        },
     )
 
 

--- a/dashboard/utils/plotly.py
+++ b/dashboard/utils/plotly.py
@@ -32,6 +32,7 @@ def format_labels(labels, wrap=None, truncate=None, separator="..."):
 
     for label in labels:
         original_label = label
+        label_hash = str(abs(hash(original_label)))[:6]
 
         if truncate and len(label) > truncate:
             words = re.split(r"[\s_]", label)
@@ -40,7 +41,7 @@ def format_labels(labels, wrap=None, truncate=None, separator="..."):
             else:
                 first_part = words[0][: truncate // 2]
                 last_part = words[-1][-truncate // 2 :]
-                label = f"{first_part}{separator}{last_part}<span style='display:none'>_{hash(original_label)}</span>"
+                label = f"{first_part}{separator}{last_part}<span style='display:none'>_{label_hash}</span>"
 
         elif wrap and len(label) > wrap:
             label = "<br>".join(text_wrap(label, wrap))


### PR DESCRIPTION
This PR addresses the label overextension in the "Received Samples per Laboratory Center" plot by implementing proper label truncation. A unique hash is now generated before truncating, preventing different centers from being incorrectly grouped under the same shortened label. Also includes a fix for the y-axis scaling.

Closes [#257](https://github.com/BU-ISCIII/relecov-platform/issues/257)