### PR TITLE
Adapted code to renamed fields. Included FIELD_EMPTY_VALUES in core-config

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -76,7 +76,7 @@ class ChromosomeAdmin(admin.ModelAdmin):
 
 
 class LineageInfoAdmin(admin.ModelAdmin):
-    list_display = ["lineage_name"]
+    list_display = ["lineage_assignment"]
 
 
 class LineageFieldsAdmin(admin.ModelAdmin):

--- a/core/api/utils/bioinfo_metadata.py
+++ b/core/api/utils/bioinfo_metadata.py
@@ -28,7 +28,7 @@ def split_bioinfo_data(data, schema_obj):
 
 def get_analysis_defined(s_obj):
     return core.models.BioinfoAnalysisValue.objects.filter(
-        bioinfo_analysis_fieldID__property_name="analysis_date", sample=s_obj
+        bioinfo_analysis_fieldID__property_name="bioinformatics_analysis_date", sample=s_obj
     ).values_list("value", flat=True)
 
 

--- a/core/api/utils/bioinfo_metadata.py
+++ b/core/api/utils/bioinfo_metadata.py
@@ -28,7 +28,8 @@ def split_bioinfo_data(data, schema_obj):
 
 def get_analysis_defined(s_obj):
     return core.models.BioinfoAnalysisValue.objects.filter(
-        bioinfo_analysis_fieldID__property_name="bioinformatics_analysis_date", sample=s_obj
+        bioinfo_analysis_fieldID__property_name="bioinformatics_analysis_date",
+        sample=s_obj,
     ).values_list("value", flat=True)
 
 

--- a/core/api/utils/common_functions.py
+++ b/core/api/utils/common_functions.py
@@ -22,7 +22,7 @@ def get_schema_version_if_exists(data):
 
 def get_analysis_defined(s_obj):
     return core.models.BioinfoAnalysisValue.objects.filter(
-        bioinfo_analysis_fieldID__property_name="analysis_date", sample=s_obj
+        bioinfo_analysis_fieldID__property_name="bioinformatics_analysis_date", sample=s_obj
     ).values_list("value", flat=True)
 
 

--- a/core/api/utils/common_functions.py
+++ b/core/api/utils/common_functions.py
@@ -22,7 +22,8 @@ def get_schema_version_if_exists(data):
 
 def get_analysis_defined(s_obj):
     return core.models.BioinfoAnalysisValue.objects.filter(
-        bioinfo_analysis_fieldID__property_name="bioinformatics_analysis_date", sample=s_obj
+        bioinfo_analysis_fieldID__property_name="bioinformatics_analysis_date",
+        sample=s_obj,
     ).values_list("value", flat=True)
 
 

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -41,16 +41,16 @@ import core.config
                 "authors": "",
                 "experiment_alias": "",
                 "experiment_title": "",
-                "fastq_r1_md5": "b5242d60471e5a5a97b35531dbbe8c30",
-                "fastq_r2_md5": "57525c5a1ec992098e652aa01b366d69",
+                "sequence_file_R1_md5": "b5242d60471e5a5a97b35531dbbe8c30",
+                "sequence_file_R2_md5": "57525c5a1ec992098e652aa01b366d69",
                 "gisaid_id": "EPI_ISL_8625444",
                 "microbiology_lab_sample_id": "20183102",
-                "r1_fastq_filepath": "/media/data/relecov/",
-                "r2_fastq_filepath": "/media/data/relecov/",
+                "sequence_file_path_R1": "/media/data/relecov/",
+                "sequence_file_path_R2": "/media/data/relecov/",
                 "schema_name": "relecov",
                 "schema_version": "",
-                "sequence_file_R1_fastq": "20183102_R1.fastq.gz",
-                "sequence_file_R2_fastq": "20183102_R2.fastq.gz",
+                "sequence_file_R1": "20183102_R1.fastq.gz",
+                "sequence_file_R2": "20183102_R2.fastq.gz",
                 "sequencing_sample_id": "20183102",
                 "study_alias": "",
                 "study_id": "",
@@ -68,16 +68,16 @@ import core.config
             "authors": serializers.CharField(required=False),
             "experiment_alias": serializers.CharField(required=False),
             "experiment_title": serializers.CharField(required=False),
-            "fastq_r1_md5": serializers.CharField(),
-            "fastq_r2_md5": serializers.CharField(),
+            "sequence_file_R1_md5": serializers.CharField(),
+            "sequence_file_R2_md5": serializers.CharField(),
             "gisaid_id": serializers.CharField(required=False),
             "microbiology_lab_sample_id": serializers.CharField(),
-            "r1_fastq_filepath": serializers.CharField(),
-            "r2_fastq_filepath": serializers.CharField(),
+            "sequence_file_path_R1": serializers.CharField(),
+            "sequence_file_path_R2": serializers.CharField(),
             "schema_name": serializers.CharField(),
             "schema_version": serializers.CharField(),
-            "sequence_file_R1_fastq": serializers.CharField(),
-            "sequence_file_R2_fastq": serializers.CharField(),
+            "sequence_file_R1": serializers.CharField(),
+            "sequence_file_R2": serializers.CharField(),
             "sequencing_sample_id": serializers.CharField(),
             "study_alias": serializers.CharField(required=False),
             "study_id": serializers.CharField(required=False),
@@ -155,10 +155,9 @@ def create_sample_data(request):
             if "ERROR" in result:
                 return Response(result, status=status.HTTP_206_PARTIAL_CONTENT)
             # check that the ena_sample_accession is not empty or "Not Provided"
-            if (
-                split_data["ena"]["ena_sample_accession"] != "Not Provided"
-                and split_data["ena"]["ena_sample_accession"] != ""
-                and split_data["ena"]["ena_sample_accession"] is not None
+            if not any(
+                x == split_data["ena"]["ena_sample_accession"]
+                for x in core.config.FIELD_EMPTY_VALUES
             ):
                 # Save entry in update state table for valid ena_sample_accession
                 sample_obj.update_state("Ena")
@@ -210,7 +209,7 @@ def create_sample_data(request):
             "Example",
             description="Variant example",
             value={
-                "analysis_date": "20220705",
+                "bioinformatics_analysis_date": "20220705",
                 "assembly": "None",
                 "assembly_params": "None",
                 "bioinformatics_protocol_software_name": "nf-core/viralrecon",
@@ -235,17 +234,17 @@ def create_sample_data(request):
                 "if_mapping_other": "None",
                 "if_preprocessing_other": "None",
                 "lineage_algorithm_software_version": "PUSHER-v1.9",
-                "lineage_analysis_constellation_version": "v0.1.10",
-                "lineage_analysis_date": "2022-07-05",
-                "lineage_analysis_scorpio_version": "0.3.17",
-                "lineage_analysis_software_name": "pangolin",
-                "lineage_analysis_software_version": "4.0.6",
+                "lineage_assignment_constellation_version": "v0.1.10",
+                "lineage_assignment_date": "2022-07-05",
+                "lineage_assignment_scorpio_version": "0.3.17",
+                "lineage_assignment_software_name": "pangolin",
+                "lineage_assignment_software_version": "4.0.6",
                 "lineage_name": "B.1.1.7",
                 "long_table_path": "",
                 "mapping_params": "--seed 1",
                 "mapping_software_name": "BOWTIE2_ALIGN",
                 "mapping_software_version": "2.4.4",
-                "number_of_base_pairs_sequenced": "9024968",
+                "number_of_reads_sequenced": "9024968",
                 "number_of_samples_in_run": "60",
                 "number_of_variants_in_consensus": "34",
                 "number_of_variants_with_effect": "22",
@@ -257,13 +256,13 @@ def create_sample_data(request):
                 "preprocessing_params": "--cut_front --cut_tail --trim_poly_x --cut_mean_quality 30 --qualified_quality_phred 30 --unqualified_percent_limit 10 --length_required 50",
                 "preprocessing_software_name": "FASTP",
                 "preprocessing_software_version": "0.23.2",
-                "qc_filtered": "573984",
+                "pass_reads": "573984",
                 "reference_genome_accession": "NC_045512.2",
                 "schema_name": "RELECOV schema",
                 "schema_version": "1.0.0",
-                "sequence_file_R1_fastq": "2018086_R1.fastq.gz",
+                "sequence_file_R1": "2018086_R1.fastq.gz",
                 "sequence_file_R1_md5": "eab8b05ef27f4f5cba5cddf6ad627de2",
-                "sequence_file_R2_fastq": "2018086_R2.fastq.gz",
+                "sequence_file_R2": "2018086_R2.fastq.gz",
                 "sequence_file_R2_md5": "d82a37aa970df2b8bf8f547ca7c18ac8",
                 "sequencing_sample_id": "254866",
                 "variant_calling_params": "--ignore-overlaps --count-orphans --no-BAQ --max-depth 0 --min-BQ 0';-t 0.25 -q 20 -m 10",
@@ -276,7 +275,7 @@ def create_sample_data(request):
     request=inline_serializer(
         name="create_bioinfo_metadata",
         fields={
-            "analysis_date": serializers.CharField(),
+            "bioinformatics_analysis_date": serializers.CharField(),
             "assembly": serializers.CharField(),
             "assembly_params": serializers.CharField(),
             "bioinformatics_protocol_software_name": serializers.CharField(),
@@ -303,18 +302,18 @@ def create_sample_data(request):
             "if_mapping_other": serializers.CharField(required=False),
             "if_preprocessing_other": serializers.CharField(required=False),
             "lineage_algorithm_software_version": serializers.CharField(),
-            "lineage_analysis_constellation_version": serializers.CharField(),
-            "lineage_analysis_date": serializers.CharField(),
-            "lineage_analysis_scorpio_version": serializers.CharField(),
-            "lineage_analysis_software_name": serializers.CharField(),
-            "lineage_analysis_software_version": serializers.CharField(),
+            "lineage_assignment_constellation_version": serializers.CharField(),
+            "lineage_assignment_date": serializers.CharField(),
+            "lineage_assignment_scorpio_version": serializers.CharField(),
+            "lineage_assignment_software_name": serializers.CharField(),
+            "lineage_assignment_software_version": serializers.CharField(),
             "lineage_name": serializers.CharField(),
             "long_table_path": serializers.CharField(),
             "mapping_params": serializers.CharField(),
             "mapping_software_name": serializers.CharField(),
             "mapping_software_version": serializers.CharField(),
             "ns_per_100_kbp": serializers.CharField(),
-            "number_of_base_pairs_sequenced": serializers.CharField(),
+            "number_of_reads_sequenced": serializers.CharField(),
             "number_of_variants_in_consensus": serializers.CharField(),
             "number_of_variants_with_effect": serializers.CharField(),
             "per_Ns": serializers.CharField(),
@@ -325,13 +324,13 @@ def create_sample_data(request):
             "preprocessing_params": serializers.CharField(),
             "preprocessing_software_name": serializers.CharField(),
             "preprocessing_software_version": serializers.CharField(),
-            "qc_filtered": serializers.CharField(),
+            "pass_reads": serializers.CharField(),
             "reference_genome_accession": serializers.CharField(),
             "schema_name": serializers.CharField(),
             "schema_version": serializers.CharField(),
-            "sequence_file_R1_fastq": serializers.CharField(),
+            "sequence_file_R1": serializers.CharField(),
             "sequence_file_R1_md5": serializers.CharField(),
-            "sequence_file_R2_fastq": serializers.CharField(),
+            "sequence_file_R2": serializers.CharField(),
             "sequence_file_R2_md5": serializers.CharField(),
             "sequencing_sample_id": serializers.CharField(),
             "variant_calling_params": serializers.CharField(),
@@ -376,9 +375,9 @@ def create_bioinfo_metadata(request):
         )
 
     analysis_defined = core.api.utils.bioinfo_metadata.get_analysis_defined(sample_obj)
-    analysis_date = data.get("analysis_date", None)
-    if analysis_date is not None:
-        if analysis_date in list(analysis_defined):
+    bioinformatics_analysis_date = data.get("bioinformatics_analysis_date", None)
+    if bioinformatics_analysis_date is not None:
+        if bioinformatics_analysis_date in list(analysis_defined):
             return Response(
                 {"ERROR": core.config.ERROR_ANALYSIS_ALREADY_DEFINED},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -528,7 +527,7 @@ def create_variant_data(request):
         analysis_defined = core.api.utils.variants.get_variant_analysis_defined(
             sample_obj
         )
-        if data["analysis_date"] in list(analysis_defined):
+        if data["bioinformatics_analysis_date"] in list(analysis_defined):
             return Response(
                 {"ERROR": core.config.ERROR_ANALYSIS_ALREADY_DEFINED},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -545,7 +544,7 @@ def create_variant_data(request):
 
         for v_data in data["variants"]:
             split_data = core.api.utils.variants.split_variant_data(
-                v_data, sample_obj, data["analysis_date"]
+                v_data, sample_obj, data["bioinformatics_analysis_date"]
             )
             if "ERROR" in split_data:
                 error = {"ERROR": split_data}

--- a/core/config.py
+++ b/core/config.py
@@ -100,6 +100,16 @@ HEADING_FOR_VARIANT_TABLE_DISPLAY = [
     "hgvs_p_1_letter",
 ]
 FIELD_FOR_GETTING_SAMPLE_ID = "Sample ID given for sequencing"
+FIELD_EMPTY_VALUES = [
+    None,
+    "",
+    "None",
+    "Not Provided",
+    "Not Applicable",
+    "Not Collected",
+    "Not Provided [SNOMED:434941000124101]",
+    "Not Provided [GENEPIO:0001668]",
+]
 
 MAIN_SCHEMA_STRUCTURE = ["$schema", "required", "type", "properties"]
 NO_SELECTED_LABEL_WAS_DONE = (

--- a/core/config.py
+++ b/core/config.py
@@ -64,12 +64,12 @@ HEADING_FOR_BASIC_SAMPLE_DATA = [
     "Recorded Date",
 ]
 HEADING_FOR_FASTQ_SAMPLE_DATA = [
-    "Sequence file R1 fastq",
-    "Sequence file R2 fastq",
-    "Filepath R1 fastq",
-    "Filepath R2 fastq",
-    "Fastq md5 r1",
-    "Fastq md5 r2",
+    "Sequence file R1",
+    "Sequence file R2",
+    "Filepath R1",
+    "Filepath R2",
+    "Sequence file R1 md5",
+    "Sequence file R2 md5",
 ]
 HEADING_SCHEMA_DISPLAY = [
     "Property",
@@ -127,12 +127,12 @@ FIELDS_ON_SAMPLE_TABLE = [
     "microbiology_lab_sample_id",
     "sequencing_sample_id",
     "submitting_lab_sample_id",
-    "sequence_file_R1_fastq",
-    "sequence_file_R2_fastq",
-    "fastq_r1_md5",
-    "fastq_r2_md5",
-    "r1_fastq_filepath",
-    "r2_fastq_filepath",
+    "sequence_file_R1",
+    "sequence_file_R2",
+    "sequence_file_R1_md5",
+    "sequence_file_R2_md5",
+    "sequence_file_path_R1",
+    "sequence_file_path_R2",
 ]
 FIELDS_ON_ENA_TABLE = [
     "bioproject_accession_ENA",

--- a/core/models.py
+++ b/core/models.py
@@ -956,7 +956,9 @@ class VariantInSample(models.Model):
     variantID_id = models.ForeignKey(
         Variant, on_delete=models.CASCADE, null=True, blank=True
     )
-    bioinformatics_analysis_date = models.CharField(max_length=100, null=True, blank=True)
+    bioinformatics_analysis_date = models.CharField(
+        max_length=100, null=True, blank=True
+    )
     dp = models.CharField(max_length=10, null=True, blank=True)
     ref_dp = models.CharField(max_length=10, null=True, blank=True)
     alt_dp = models.CharField(max_length=10, null=True, blank=True)

--- a/core/models.py
+++ b/core/models.py
@@ -705,12 +705,12 @@ class Sample(models.Model):
     submitting_lab_sample_id = models.CharField(max_length=80, null=True, blank=True)
     collecting_institution = models.CharField(max_length=120, null=True, blank=True)
     submitting_institution = models.CharField(max_length=120, null=True, blank=True)
-    sequence_file_R1_fastq = models.CharField(max_length=80, null=True, blank=True)
-    sequence_file_R2_fastq = models.CharField(max_length=80, null=True, blank=True)
+    sequence_file_R1 = models.CharField(max_length=80, null=True, blank=True)
+    sequence_file_R2 = models.CharField(max_length=80, null=True, blank=True)
     sequence_file_R1_md5 = models.CharField(max_length=80, null=True, blank=True)
     sequence_file_R2_md5 = models.CharField(max_length=80, null=True, blank=True)
-    r1_fastq_filepath = models.CharField(max_length=120, null=True, blank=True)
-    r2_fastq_filepath = models.CharField(max_length=120, null=True, blank=True)
+    sequence_file_path_R1 = models.CharField(max_length=120, null=True, blank=True)
+    sequence_file_path_R2 = models.CharField(max_length=120, null=True, blank=True)
     sequencing_date = models.DateTimeField(auto_now_add=False, null=True, blank=True)
 
     created_at = models.DateTimeField(auto_now_add=True)
@@ -789,10 +789,10 @@ class Sample(models.Model):
 
     def get_fastq_data(self):
         data = []
-        data.append(self.sequence_file_R1_fastq)
-        data.append(self.sequence_file_R2_fastq)
-        data.append(self.r1_fastq_filepath)
-        data.append(self.r2_fastq_filepath)
+        data.append(self.sequence_file_R1)
+        data.append(self.sequence_file_R2)
+        data.append(self.sequence_file_path_R1)
+        data.append(self.sequence_file_path_R2)
         data.append(self.sequence_file_R1_md5)
         data.append(self.sequence_file_R2_md5)
         return data
@@ -956,7 +956,7 @@ class VariantInSample(models.Model):
     variantID_id = models.ForeignKey(
         Variant, on_delete=models.CASCADE, null=True, blank=True
     )
-    analysis_date = models.CharField(max_length=100, null=True, blank=True)
+    bioinformatics_analysis_date = models.CharField(max_length=100, null=True, blank=True)
     dp = models.CharField(max_length=10, null=True, blank=True)
     ref_dp = models.CharField(max_length=10, null=True, blank=True)
     alt_dp = models.CharField(max_length=10, null=True, blank=True)

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -2,6 +2,7 @@
 import core.models
 import core.utils.samples
 import core.utils.schema
+import core.config
 
 
 def get_bio_analysis_stats_from_lab(lab_name=None):
@@ -87,7 +88,7 @@ def get_bioinfo_analyis_fields_utilization(schema_obj=None):
             continue
         # b_data[schema_name][f_name] = [count]
         count_not_empty = b_field_obj_info.exclude(
-            value__in=["None", "Not Provided", ""]
+            value__in=core.config.FIELD_EMPTY_VALUES
         ).count()
         b_data["fields_value"][f_name] = count_not_empty
         if count_not_empty == 0:

--- a/core/utils/lineage.py
+++ b/core/utils/lineage.py
@@ -8,7 +8,6 @@ def get_lineages_list():
     """Function gets the lineage names and return then in an ordered list"""
     # Exclude unassigned and not provided lineages
     invalid_lineages = [
-        "Not Provided [GENEPIO:0001668]",
         "Omicron (Unassigned)",
         "Probable Omicron (Unassigned)",
         "Unassigned",

--- a/core/utils/lineage.py
+++ b/core/utils/lineage.py
@@ -1,6 +1,7 @@
 # Local imports
 import core.utils.samples
 import core.models
+import core.config
 
 
 def get_lineages_list():
@@ -11,10 +12,10 @@ def get_lineages_list():
         "Omicron (Unassigned)",
         "Probable Omicron (Unassigned)",
         "Unassigned",
-    ]
+    ].extend(core.config.FIELD_EMPTY_VALUES)
     return list(
         core.models.LineageValues.objects.all()
-        .filter(lineage_fieldID__property_name__iexact="lineage_name")
+        .filter(lineage_fieldID__property_name__iexact="lineage_assignment")
         .exclude(value__in=invalid_lineages)
         .values_list("value", flat=True)
         .distinct()

--- a/core/utils/public_db.py
+++ b/core/utils/public_db.py
@@ -2,6 +2,7 @@
 import core.models
 import core.utils.plotly_graphics
 import dashboard.utils.generic_graphic_data
+import core.config
 from django.db.models import Q
 
 
@@ -14,7 +15,7 @@ def get_public_accession_from_sample_lab(p_field, sample_objs=None):
             core.models.PublicDatabaseValues.objects.filter(
                 public_database_fieldID__property_name__iexact=p_field,
             )
-            .exclude(Q(value__icontains="Not Provided") | Q(value__isnull=True))
+            .exclude(Q(value__in=core.config.FIELD_EMPTY_VAUES) | Q(value__isnull=True))
             .values_list(
                 "sampleID__submitting_institution",
                 "sampleID__sequencing_sample_id",
@@ -27,7 +28,7 @@ def get_public_accession_from_sample_lab(p_field, sample_objs=None):
                 sampleID__in=sample_objs,
                 public_database_fieldID__property_name__exact=p_field,
             )
-            .exclude(Q(value__icontains="Not Provided") | Q(value__isnull=True))
+            .exclude(Q(value__in=core.config.FIELD_EMPTY_VAUES) | Q(value__isnull=True))
             .values_list("sampleID__sequencing_sample_id", "value")
         )
 

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -18,12 +18,12 @@ from django.db.models.functions import ExtractWeek, ExtractIsoYear, Concat, Cast
 
 # Local imports
 import core.models
-import core.utils.lineage
 import core.utils.variants
 import core.utils.rest_api
 import core.utils.generic_functions
 import core.utils.public_db
 import dashboard.models
+import core.config
 from relecov_platform import settings as relecov_platform_settings
 
 import time
@@ -53,9 +53,9 @@ def pre_proc_calculation_date():
         else:
             d_format = "%Y%m%d"
         for sample in data.keys():
-            if sample in invalid_samples:
+            if sample in invalid_samples or data[sample] is None:
                 continue
-            if data[sample] == "Not Provided [GENEPIO:0001668]":
+            if any(x == data[sample] for x in core.config.FIELD_EMPTY_VALUES):
                 continue
             if data[sample]:
                 f_date = datetime.strptime(data[sample], d_format)
@@ -168,10 +168,9 @@ def pre_proc_variant_graphic():
     print("Iterating over sample-date fetched data")
     for date, samples in date_sample.items():
         invalid_values = [
-            "Not Provided [GENEPIO:0001668]",
             "Omicron (Unassigned)",
             "Probable Omicron (Unassigned)",
-        ]
+        ].extend(core.config.FIELD_EMPTY_VALUES)
         variant_samples = (
             core.models.LineageValues.objects.filter(
                 lineage_fieldID__property_name="variant_name",
@@ -242,15 +241,14 @@ def pre_proc_variations_per_lineage(chromosome=None):
 
     lineage_data = {}
     invalid_lineages = [
-        "Not Provided [GENEPIO:0001668]",
         "Omicron (Unassigned)",
         "Probable Omicron (Unassigned)",
         "Unassigned",
-    ]
+    ].extend(core.config.FIELD_EMPTY_VALUES)
     start = time.time()
     # Grab lineages matching selected lineage
     filtered_lineage_queryset = core.models.LineageValues.objects.filter(
-        lineage_fieldID__property_name="lineage_name",
+        lineage_fieldID__property_name="lineage_assignment",
     ).exclude(value__in=invalid_lineages)
     valid_lineages = filtered_lineage_queryset.values_list(
         "value", flat=True
@@ -401,7 +399,7 @@ def pre_proc_based_pairs_sequenced():
         sample_name = ct_value["Sample name"]
         base_value = (
             core.models.BioinfoAnalysisValue.objects.filter(
-                bioinfo_analysis_fieldID__property_name__exact="number_of_base_pairs_sequenced",
+                bioinfo_analysis_fieldID__property_name__exact="number_of_reads_sequenced",
                 sample__collecting_lab_sample_id__exact=sample_name,
             )
             .last()
@@ -630,29 +628,28 @@ def pre_proc_host_info():
         host_info_json["gender_values"] = {"ERROR": gender_values}
     else:
         label_val_dict = dict(zip(gender_label, gender_values))
-        empty_vals = label_val_dict.get("", 0)
-        if "" in label_val_dict.keys():
-            del label_val_dict[""]
-        if empty_vals:
-            if "Not Provided" in label_val_dict:
-                label_val_dict["Not Provided"] += empty_vals
-            else:
-                label_val_dict["Not Provided"] = empty_vals
-
+        for field in core.config.FIELD_EMPTY_VALUES:
+            # Group all Not provided values together
+            if field not in label_val_dict.keys() or field == "Not Provided":
+                continue
+            label_val_dict["Not Provided"] = (
+                label_val_dict.get("Not Provided", 0) + label_val_dict[field]
+            )
+            del label_val_dict[field]
         host_info_json["gender_label"] = list(label_val_dict.keys())
         host_info_json["gender_values"] = list(label_val_dict.values())
     # graphic for gender and age
     host_gender_data, invalid_gender_data = fetching_data_for_sex_and_range_data()
-    empty_vals = host_gender_data.get("", [])
-    if "" in host_gender_data.keys():
-        del host_gender_data[""]
-    if empty_vals:
-        if "Not Provided" in host_gender_data:
-            host_gender_data["Not Provided"] = [
-                x + y for x, y in zip(host_gender_data["Not Provided"], empty_vals)
-            ]
-        else:
-            host_gender_data["Not Provided"] = empty_vals
+    for field in core.config.FIELD_EMPTY_VALUES:
+        # Group all Not provided values together
+        if field not in host_gender_data.keys() or field == "Not Provided":
+            continue
+        empty_vals_zip = zip(
+            host_gender_data.get("Not Provided", [0] * len(host_gender_data[field])),
+            host_gender_data[field],
+        )
+        host_gender_data["Not Provided"] = [x + y for x, y in empty_vals_zip]
+        del host_gender_data[field]
     total_invalid_data["invalid_gender_data"] = invalid_gender_data
     host_info_json["gender_data"] = host_gender_data
     host_age_data, invalid_age_data = fetching_data_for_range_age()

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -86,7 +86,7 @@ def pre_proc_calculation_date():
     # get sequencing date from sample table
     invalid_samples = {}
     analysis_date = core.models.BioinfoAnalysisValue.objects.filter(
-        bioinfo_analysis_fieldID__property_name__exact="analysis_date",
+        bioinfo_analysis_fieldID__property_name__exact="bioinformatics_analysis_date",
     ).values("value", "sample__collecting_lab_sample_id")
     analysis_date = convert_data_to_sample_dict(
         analysis_date, "sample__collecting_lab_sample_id", "value"


### PR DESCRIPTION
This PR adapts those parts of the code that would no longer  with the latest release of relecov-schema v3.0.6 as some fields are renamed while also including a new entry `FIELD_EMPTY_VALUES` in core/config.py to gather all values that would imply that the mentioned field is either missing, not provided or simply non-existing.

