### PR TITLE
Fix MEDIA_ROOT and Automatically Create `documents/` Folder During Installation

### DIFF
--- a/conf/template_settings.py
+++ b/conf/template_settings.py
@@ -162,7 +162,7 @@ SWAGGER_SETTINGS = {"SECURITY_DEFINITIONS": {"basic": {"type": "basic"}}}
 
 #  Media settings
 MEDIA_URL = "/documents/"
-MEDIA_ROOT = "documents/"
+MEDIA_ROOT = os.path.join(BASE_DIR, "documents/")
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/

--- a/install.sh
+++ b/install.sh
@@ -695,6 +695,16 @@ if [ $install == true ]; then
             fi
         fi
 
+        if [ ! -d $INSTALL_PATH/documents ]; then
+            echo "Creating documents folder at $INSTALL_PATH/documents"
+            mkdir -p $INSTALL_PATH/documents
+            chown $user:$apache_group $INSTALL_PATH/documents
+            chmod 775 $INSTALL_PATH/documents
+        else
+            echo "Documents folder already exists at $INSTALL_PATH/documents"
+        fi
+
+
         mkdir -p $INSTALL_PATH/$PROJECT_NAME
         rsync -rlv README.md LICENSE conf $REQUIRED_MODULES $INSTALL_PATH/
 


### PR DESCRIPTION
## Changes

This PR ensures that the `documents/` directory—used as the `MEDIA_ROOT` for file uploads—is automatically created during the installation or upgrade process of the Relecov platform.


1. **Fixes `MEDIA_ROOT` path resolution**  
   - Changed from a relative path:
     ```python
     MEDIA_ROOT = "documents/"
     ```
     to an absolute, project-relative path:
     ```python
     MEDIA_ROOT = os.path.join(BASE_DIR, "documents/")
     ```
   - This ensures Django resolves the correct storage location regardless of the working directory or execution context.

2. **Automatically creates the `documents/` directory during install**  
   - Updated `install_relecov.sh` to:
     - Check for `$INSTALL_PATH/documents`
     - Create it if missing
     - Set appropriate ownership (`$user:$apache_group`) and permissions (`775`)
