### PR TITLE
Updated variant creation to support new key bioinformatics_analysis_date and handle stringfied variant list

### DIFF
--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -92,7 +92,7 @@ def get_variant_id(data):
 
 def get_variant_analysis_defined(s_obj):
     return core.models.VariantInSample.objects.filter(sampleID_id=s_obj).values_list(
-        "analysis_date", flat=True
+        "bioinformatics_analysis_date", flat=True
     )
 
 

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -538,7 +538,7 @@ def create_variant_data(request):
                 {"ERROR": core.config.ERROR_VARIANT_INFORMATION_NOT_DEFINED},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        
+
         import ast
 
         if isinstance(data["variants"], str):

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -16,6 +16,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import serializers
 from django.http import QueryDict
+import ast
 
 # Local imports
 import core.urls
@@ -538,8 +539,6 @@ def create_variant_data(request):
                 {"ERROR": core.config.ERROR_VARIANT_INFORMATION_NOT_DEFINED},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-
-        import ast
 
         if isinstance(data["variants"], str):
             try:

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -538,6 +538,18 @@ def create_variant_data(request):
                 {"ERROR": core.config.ERROR_VARIANT_INFORMATION_NOT_DEFINED},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        
+        import ast
+
+        if isinstance(data["variants"], str):
+            try:
+                data["variants"] = ast.literal_eval(data["variants"])
+            except Exception as e:
+                return Response(
+                    {"ERROR": f"Unable to parse variants: {str(e)}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
         found_error = False
         v_in_sample_list = []
         v_an_list = []


### PR DESCRIPTION

### Description
This pull request includes two main improvements to enhance compatibility and data handling in the variant creation endpoint:

- **Key update**: Replaces the use of `analysis_date` with the new standardized key `bioinformatics_analysis_date` when checking for existing variant analyses.
- **Input flexibility**: Adds support for parsing `variants` when provided as a stringified list (e.g., via JSON where the list is a string), using `ast.literal_eval`.

These changes are required due to recent modifications in the structure of `long_table.json` files and ensure smoother API integration and fewer submission errors.