### PR TITLE
Fix incorrect usage of .extend() when initializing variables

### DIFF
--- a/core/utils/lineage.py
+++ b/core/utils/lineage.py
@@ -11,7 +11,8 @@ def get_lineages_list():
         "Omicron (Unassigned)",
         "Probable Omicron (Unassigned)",
         "Unassigned",
-    ].extend(core.config.FIELD_EMPTY_VALUES)
+    ]
+    invalid_lineages.extend(core.config.FIELD_EMPTY_VALUES)
     return list(
         core.models.LineageValues.objects.all()
         .filter(lineage_fieldID__property_name__iexact="lineage_assignment")

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -170,7 +170,8 @@ def pre_proc_variant_graphic():
         invalid_values = [
             "Omicron (Unassigned)",
             "Probable Omicron (Unassigned)",
-        ].extend(core.config.FIELD_EMPTY_VALUES)
+        ]
+        invalid_values.extend(core.config.FIELD_EMPTY_VALUES)
         variant_samples = (
             core.models.LineageValues.objects.filter(
                 lineage_fieldID__property_name="variant_name",
@@ -244,7 +245,8 @@ def pre_proc_variations_per_lineage(chromosome=None):
         "Omicron (Unassigned)",
         "Probable Omicron (Unassigned)",
         "Unassigned",
-    ].extend(core.config.FIELD_EMPTY_VALUES)
+    ]
+    invalid_lineages.extend(core.config.FIELD_EMPTY_VALUES)
     start = time.time()
     # Grab lineages matching selected lineage
     filtered_lineage_queryset = core.models.LineageValues.objects.filter(


### PR DESCRIPTION
## PR Description
This PR corrects the way the variable list is initialized by separating the list declaration from the .extend() call.