### PR TITLE
Empty Lineages VOC Dashboard Due to Duplicated Index in DataFrame

### DIFF
--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -147,12 +147,15 @@ def create_lineages_variations_graphic():
         sub_data_df["Collection ISOWeek"] = sub_data_df["Collection date"].dt.strftime(
             "%Y-W%V"
         )
-        
-        agg_df = sub_data_df.groupby(["Lineage", "Collection ISOWeek"])["samples"].sum().reset_index()
 
-        graph_df = (
-            agg_df.set_index(["Collection ISOWeek", "Lineage"])
-            .unstack("Lineage")
+        agg_df = (
+            sub_data_df.groupby(["Lineage", "Collection ISOWeek"])["samples"]
+            .sum()
+            .reset_index()
+        )
+
+        graph_df = agg_df.set_index(["Collection ISOWeek", "Lineage"]).unstack(
+            "Lineage"
         )
 
         # remove the sample text from column

--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -147,15 +147,12 @@ def create_lineages_variations_graphic():
         sub_data_df["Collection ISOWeek"] = sub_data_df["Collection date"].dt.strftime(
             "%Y-W%V"
         )
-
-        agg_df = (
-            sub_data_df.groupby(["Lineage", "Collection ISOWeek"])["samples"]
-            .sum()
-            .reset_index()
-        )
-
-        graph_df = agg_df.set_index(["Collection ISOWeek", "Lineage"]).unstack(
-            "Lineage"
+        
+        agg_df = sub_data_df.drop_duplicates(subset=["Lineage", "Collection ISOWeek"])
+        
+        graph_df = (
+            agg_df.set_index(["Collection ISOWeek", "Lineage"])
+            .unstack("Lineage")
         )
 
         # remove the sample text from column

--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -147,11 +147,12 @@ def create_lineages_variations_graphic():
         sub_data_df["Collection ISOWeek"] = sub_data_df["Collection date"].dt.strftime(
             "%Y-W%V"
         )
+        
+        agg_df = sub_data_df.groupby(["Lineage", "Collection ISOWeek"])["samples"].sum().reset_index()
 
         graph_df = (
-            sub_data_df.drop(["Collection date"], axis=1)
-            .set_index(["Lineage", "Collection ISOWeek"])
-            .unstack(["Lineage"])
+            agg_df.set_index(["Collection ISOWeek", "Lineage"])
+            .unstack("Lineage")
         )
 
         # remove the sample text from column

--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -147,12 +147,11 @@ def create_lineages_variations_graphic():
         sub_data_df["Collection ISOWeek"] = sub_data_df["Collection date"].dt.strftime(
             "%Y-W%V"
         )
-        
+
         agg_df = sub_data_df.drop_duplicates(subset=["Lineage", "Collection ISOWeek"])
-        
-        graph_df = (
-            agg_df.set_index(["Collection ISOWeek", "Lineage"])
-            .unstack("Lineage")
+
+        graph_df = agg_df.set_index(["Collection ISOWeek", "Lineage"]).unstack(
+            "Lineage"
         )
 
         # remove the sample text from column


### PR DESCRIPTION
### Description

Closes [#286](https://github.com/BU-ISCIII/relecov-platform/issues/286), where the "Lineages VOC" dashboard was rendering empty despite valid data ranges being selected.

### Root Cause

The callback in `variationLineageOverTime` failed due to a `ValueError` during the `unstack()` operation:

`ValueError: Index contains duplicate entries, cannot reshape`


This was caused by multiple entries with the same `["Lineage", "Collection ISOWeek"]` combination in the DataFrame passed to `.unstack()`.

## Solution

We addressed this by removing duplicated entries **before** the groupby operation:


```python
sub_data_df = sub_data_df.drop_duplicates(subset=["Lineage", "Collection ISOWeek"])
