### PR TITLE
Unify empty and non-informative gender keys to prevent crash in hostInfo view

### DIFF
--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -393,7 +393,7 @@ def pre_proc_library_kit_pcr_1():
 def pre_proc_based_pairs_sequenced():
     based_pairs = {}
     pcr_ct_1_values = core.utils.rest_api.get_sample_parameter_data(
-        {"sample_project_name": "relecov", "parameter": "diagnostic_pcr_Ct_value_1"}
+        {"sample_project_name": "Relecov", "parameter": "diagnostic_pcr_Ct_value_1"}
     )
     samps_db = core.models.Sample.objects.all().values_list("collecting_lab_sample_id")
     if "ERROR" in pcr_ct_1_values:
@@ -624,12 +624,20 @@ def pre_proc_host_info():
                     years_fields[gender][year_age] += counts
                 else:
                     years_fields[gender][year_age] = counts
+        for invalid_key in ['', 'Not Applicable']:
+            if invalid_key in years_fields:
+                years_fields['Not Provided'] = {
+                    k: years_fields.get('Not Provided', {}).get(k, 0) + years_fields[invalid_key].get(k, 0)
+                    for k in set(years_fields[invalid_key]) | set(years_fields.get('Not Provided', {}))
+                }
+                del years_fields[invalid_key]
         for key, values in years_fields.items():
             tmp_range_per_key[key], tmp_invalid_data = split_age_in_ranges(values)
             invalid_data += tmp_invalid_data
-            tmp_max_value = max(tmp_range_per_key[key].keys())
-            if tmp_max_value > max_value:
-                max_value = tmp_max_value
+            if tmp_range_per_key[key]:
+                tmp_max_value = max(tmp_range_per_key[key].keys())
+                if tmp_max_value > max_value:
+                    max_value = tmp_max_value
 
         age_range_list = []
         for idx in range(max_value + 1):

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -624,11 +624,13 @@ def pre_proc_host_info():
                     years_fields[gender][year_age] += counts
                 else:
                     years_fields[gender][year_age] = counts
-        for invalid_key in ['', 'Not Applicable']:
+        for invalid_key in ["", "Not Applicable"]:
             if invalid_key in years_fields:
-                years_fields['Not Provided'] = {
-                    k: years_fields.get('Not Provided', {}).get(k, 0) + years_fields[invalid_key].get(k, 0)
-                    for k in set(years_fields[invalid_key]) | set(years_fields.get('Not Provided', {}))
+                years_fields["Not Provided"] = {
+                    k: years_fields.get("Not Provided", {}).get(k, 0)
+                    + years_fields[invalid_key].get(k, 0)
+                    for k in set(years_fields[invalid_key])
+                    | set(years_fields.get("Not Provided", {}))
                 }
                 del years_fields[invalid_key]
         for key, values in years_fields.items():

--- a/dashboard/utils/met_sequencing.py
+++ b/dashboard/utils/met_sequencing.py
@@ -100,8 +100,7 @@ def sequencing_graphics():
         col_names=["library_preparation", "number"],
         legend=[""],
         yaxis={"title": "Number of samples"},
-        options={"title": "Library Preparation", "height": 400,
-                 "truncate_labels": 20},
+        options={"title": "Library Preparation", "height": 400, "truncate_labels": 20},
     )
     read_length_df = fetch_sequencing_data(
         project_field="read_length",
@@ -124,7 +123,7 @@ def sequencing_graphics():
         options={
             "title": "Read Length Distribution",
             "height": 400,
-            "width":400,
+            "width": 400,
             "xaxis": {"type": "category"},
         },
     )
@@ -138,7 +137,7 @@ def sequencing_graphics():
             "height": 400,
             "width": 400,
             "y_title": "PCR Ct Value",
-            "truncate_labels": 20
+            "truncate_labels": 20,
         },
     )
 

--- a/dashboard/utils/met_sequencing.py
+++ b/dashboard/utils/met_sequencing.py
@@ -100,7 +100,8 @@ def sequencing_graphics():
         col_names=["library_preparation", "number"],
         legend=[""],
         yaxis={"title": "Number of samples"},
-        options={"title": "Library Preparation", "height": 400},
+        options={"title": "Library Preparation", "height": 400,
+                 "truncate_labels": 20},
     )
     read_length_df = fetch_sequencing_data(
         project_field="read_length",
@@ -123,6 +124,7 @@ def sequencing_graphics():
         options={
             "title": "Read Length Distribution",
             "height": 400,
+            "width":400,
             "xaxis": {"type": "category"},
         },
     )
@@ -132,10 +134,11 @@ def sequencing_graphics():
     sequencing["cts_library"] = dashboard.utils.plotly.box_plot_graphic(
         cts_library_data,
         {
-            "title": "PCR Ct Values<br>by Library Preparation Kit",
+            "title": "PCR Ct Values by Library Preparation Kit",
             "height": 400,
-            "width": 420,
+            "width": 400,
             "y_title": "PCR Ct Value",
+            "truncate_labels": 20
         },
     )
 
@@ -144,7 +147,7 @@ def sequencing_graphics():
         cts_pcr_1["based"],
         cts_pcr_1["cts"],
         {
-            "title": "Sequenced Base Pairs<br>vs PCR Ct Values",
+            "title": "Sequenced Base Pairs vs PCR Ct Values",
             "height": 350,
             "width": 300,
             "x_title": "Number of base pairs sequenced",


### PR DESCRIPTION
### Description

This PR fixes a crash in the `/dashboard/methodology/hostInfo` view caused by empty dictionaries passed to `max()`, due to missing or invalid `host_gender` keys.

### Changes

- Unified empty (`''`) and non-informative keys (`'Not Applicable'`) into `'Not Provided'`.
- Prevented calls to `max()` on empty dictionaries.
- Ensured more robust handling of edge cases in `host_age_years` aggregation.