### PR TITLE
Fix sample matching and data retrieval in dashboard graph for percentage of reads

### DIFF
--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -395,7 +395,12 @@ def pre_proc_based_pairs_sequenced():
     pcr_ct_1_values = core.utils.rest_api.get_sample_parameter_data(
         {"sample_project_name": "Relecov", "parameter": "diagnostic_pcr_Ct_value_1"}
     )
-    samps_db = set(x[0] for x in core.models.Sample.objects.all().values_list("collecting_lab_sample_id"))
+    samps_db = set(
+        x[0]
+        for x in core.models.Sample.objects.all().values_list(
+            "collecting_lab_sample_id"
+        )
+    )
     if "ERROR" in pcr_ct_1_values:
         return pcr_ct_1_values
     for ct_value in pcr_ct_1_values:

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -395,21 +395,24 @@ def pre_proc_based_pairs_sequenced():
     pcr_ct_1_values = core.utils.rest_api.get_sample_parameter_data(
         {"sample_project_name": "Relecov", "parameter": "diagnostic_pcr_Ct_value_1"}
     )
-    samps_db = core.models.Sample.objects.all().values_list("collecting_lab_sample_id")
+    samps_db = set(x[0] for x in core.models.Sample.objects.all().values_list("collecting_lab_sample_id"))
     if "ERROR" in pcr_ct_1_values:
         return pcr_ct_1_values
     for ct_value in pcr_ct_1_values:
         sample_name = ct_value["Sample name"]
+
         if sample_name not in samps_db:
             continue
-        base_value = (
-            core.models.BioinfoAnalysisValue.objects.filter(
-                bioinfo_analysis_fieldID__property_name__exact="number_of_reads_sequenced",
-                sample__collecting_lab_sample_id__exact=sample_name,
-            )
-            .last()
-            .get_value()
-        )
+
+        base_value_qs = core.models.BioinfoAnalysisValue.objects.filter(
+            bioinfo_analysis_fieldID__property_name__exact="number_of_reads_sequenced",
+            sample__collecting_lab_sample_id__exact=sample_name,
+        ).last()
+
+        if base_value_qs is None:
+            continue
+
+        base_value = base_value_qs.get_value()
         try:
             float_base_value = float(ct_value["diagnostic_pcr_Ct_value_1"])
             base_value_int = int(base_value)
@@ -425,7 +428,6 @@ def pre_proc_based_pairs_sequenced():
             "graphic_data": based_pairs,
         }
     )
-
     return {"SUCCESS": "Success"}
 
 

--- a/dashboard/utils/met_sequencing.py
+++ b/dashboard/utils/met_sequencing.py
@@ -18,7 +18,7 @@ def sequencing_graphics():
         json_data = dashboard.utils.generic_graphic_data.get_graphic_json_data(
             graphic_name
         )
-        if json_data is None:
+        if json_data is None or json_data == {}:
             # Execute the pre-processed task to get the data
             if graphic_name == "library_kit_pcr_1":
                 result = (


### PR DESCRIPTION
## PR Description
This PR resolves an issue in the percentage graph generation of the dashboard related to the processing of the `diagnostic_pcr_Ct_value_1 values`.

The previous implementation did not correctly filter and match samples when retrieving the `number_of_reads_sequenced` values from the database.

The corrected implementation now:
- Retrieves all sample names from the database using `collecting_lab_sample_id`.
- Filters out Ct values that do not correspond to samples in the database.
- Retrieves the most recent `number_of_reads_sequenced` value per sample and ensures valid mapping.