### PR TITLE
Improve robustness of get_pre_proc_data and get_percentage_data to prevent UI crashes

### DIFF
--- a/dashboard/utils/met_bioinfo.py
+++ b/dashboard/utils/met_bioinfo.py
@@ -3,11 +3,14 @@ from collections import OrderedDict
 from statistics import mean
 
 # Local imports
+import logging
 import core.models
 import dashboard.dashboard_config
 import dashboard.utils.generic_graphic_data
 import dashboard.utils.plotly
 import dashboard.utils.generic_process_data
+
+logger = logging.getLogger(__name__)
 
 
 def bioinfo_graphics():
@@ -31,20 +34,19 @@ def bioinfo_graphics():
                 graphic_name
             )
 
-        if not isinstance(json_data, dict):
-            return {"ERROR": "Invalid data format"}
-
         tmp_json_float = {}
         for key, values in json_data.items():
             try:
                 float_key = float(key)
                 if not isinstance(values, (list, tuple)):
+                    logger.warning(
+                        f"Skipping key '{key}' because values are not a list or tuple: type={type(values).__name__}"
+                    )
                     continue
-                values_clean = [
-                    float(v) for v in values if isinstance(v, (int, float, float))
-                ]
+                values_clean = [float(v) for v in values if isinstance(v, (int, float))]
                 tmp_json_float[float_key] = values_clean
-            except (ValueError, TypeError):
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Skipping key '{key}' due to conversion error: {e}")
                 continue
 
         json_data_sorted = OrderedDict(sorted(tmp_json_float.items()))
@@ -54,7 +56,11 @@ def bioinfo_graphics():
                 try:
                     data["depth"].append(float(key))
                     data["variant"].append(mean(values))
-                except Exception:
+                except Exception as e:
+                    logger.error(
+                        f"Error processing key '{key}' with values '{values}': {e}"
+                    )
+                    print(f"[ERROR] Could not process key '{key}' due to: {e}")
                     continue
         return data
 
@@ -86,6 +92,9 @@ def bioinfo_graphics():
                         if v <= 100:
                             clean_values.append(v)
                     except ValueError:
+                        logger.warning(
+                            f"Invalid value encountered in '{graph}': '{value}' could not be converted to float"
+                        )
                         continue
 
                 per_data.append({labels_map.get(graph, graph): clean_values})

--- a/dashboard/utils/met_bioinfo.py
+++ b/dashboard/utils/met_bioinfo.py
@@ -30,15 +30,32 @@ def bioinfo_graphics():
             json_data = dashboard.utils.generic_graphic_data.get_graphic_json_data(
                 graphic_name
             )
+
+        if not isinstance(json_data, dict):
+            return {"ERROR": "Invalid data format"}
+
         tmp_json_float = {}
         for key, values in json_data.items():
-            tmp_json_float[float(key)] = values
+            try:
+                float_key = float(key)
+                if not isinstance(values, (list, tuple)):
+                    continue
+                values_clean = [
+                    float(v) for v in values if isinstance(v, (int, float, float))
+                ]
+                tmp_json_float[float_key] = values_clean
+            except (ValueError, TypeError):
+                continue
+
         json_data_sorted = OrderedDict(sorted(tmp_json_float.items()))
-        data = {}
         data = {"depth": [], "variant": []}
         for key, values in json_data_sorted.items():
-            data["depth"].append(float(key))
-            data["variant"].append(mean(values))
+            if values:
+                try:
+                    data["depth"].append(float(key))
+                    data["variant"].append(mean(values))
+                except Exception:
+                    continue
         return data
 
     def get_percentage_data():
@@ -59,18 +76,19 @@ def bioinfo_graphics():
                         bioinfo_analysis_fieldID__property_name__exact=graph
                     ).values_list("value", flat=True)
                 )
-                try:
-                    per_data.append(
-                        {labels_map.get(graph, graph): list(map(float, str_data))}
-                    )
-                except ValueError:
-                    filter_list = []
-                    for value in str_data:
-                        try:
-                            filter_list.append(float(value))
-                        except ValueError:
-                            continue
-                    per_data.append({labels_map.get(graph, graph): filter_list})
+
+                clean_values = []
+                for value in str_data:
+                    try:
+                        v = float(value)
+                        if v < 0:
+                            v = 0.0  # negative values
+                        if v <= 100:
+                            clean_values.append(v)
+                    except ValueError:
+                        continue
+
+                per_data.append({labels_map.get(graph, graph): clean_values})
 
         return per_data
 


### PR DESCRIPTION
## PR Description
This PR introduces several robustness and reliability improvements to the utility functions get_pre_proc_data and get_percentage_data, which are used to retrieve and preprocess data for dashboard visualizations.

#### Changes included: 
_get_pre_proc_data(): & get_percentage_data():_
- Added try-except blocks when casting keys to float and computing the mean of values.
- Ignored empty or malformed data gracefully.
- Included logging of specific issues (non-numeric keys, invalid values, failed conversions).
- Ensured the function always returns a valid {"depth": [], "variant": []} structure or an informative {"ERROR": ...} message.

In addition, a filter of max 100 has been applied to the graph whose X-axis goes from 0 to 100.
