### PR TITLE
Ensure consistent filtering of `CT values > 40` and add `logging` for traceability for `met_sequencing`

### DIFF
--- a/dashboard/utils/met_sequencing.py
+++ b/dashboard/utils/met_sequencing.py
@@ -1,12 +1,15 @@
 # Generic imports
 from statistics import mean
 import pandas as pd
+import logging
 
 # Local imports
 import core.utils.rest_api
 import dashboard.utils.generic_graphic_data
 import dashboard.utils.plotly
 import dashboard.utils.generic_process_data
+
+logger = logging.getLogger(__name__)
 
 
 def sequencing_graphics():
@@ -44,16 +47,40 @@ def sequencing_graphics():
                     try:
                         float_val = float(str_val)
                     except ValueError:
+                        logger.warning(
+                            f"Non-numeric CT value '{str_val}' found in bin '{key}' – skipping."
+                        )
                         continue
                     if float_val > 40:
+                        logger.info(
+                            f"Discarded CT value > 40: {float_val} in bin '{key}'"
+                        )
                         continue
                     tmp_data += [float_val] * numbers
                 data.append({key: tmp_data})
         else:
             data = {"based": [], "cts": []}
             for key, values in json_data.items():
-                data["based"].append(int(key))
-                data["cts"].append(mean(values))
+                try:
+                    int_key = int(key)
+                except ValueError:
+                    logger.warning(f"Invalid bin key '{key}' – skipping.")
+                    continue
+
+                filtered_vals = [
+                    v for v in values if isinstance(v, (int, float)) and v <= 40
+                ]
+                discarded = len(values) - len(filtered_vals)
+
+                if discarded > 0:
+                    logger.info(f"{discarded} CT values > 40 discarded in bin {key}")
+
+                if not filtered_vals:
+                    logger.debug(f"All values discarded for bin {key} – skipping.")
+                    continue
+
+                data["based"].append(int_key)
+                data["cts"].append(mean(filtered_vals))
         return data
 
     def fetch_sequencing_data(project_field, columns):


### PR DESCRIPTION
## PR Description
This PR improves the robustness and consistency of the get_pre_proc_data logic inside the sequencing_graphics() function by introducing two key changes:

#### Consistent filtering of CT values > 40
Previously, CT values greater than 40 were filtered only in the "list_of_dict" output format. This PR applies the same filtering logic in the else branch to ensure consistency across all output formats.

#### Logging for discarded or invalid values
- Added logging to help trace issues during data pre-processing:
- Logs a warning when a non-numeric CT value is encountered.
- Logs when CT values > 40 are discarded (with bin/key information).
- Logs when all values in a bin are filtered out (optional debug-level log).