### PR TITLE
Implemented intranet custom view for submitters and collectors, scaled received_samples plot

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -12,7 +12,7 @@ import core.config
 
 class Profile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
-    laboratory = models.CharField(max_length=60, null=True, blank=True)
+    laboratory = models.CharField(max_length=120, null=True, blank=True)
     code_id = models.CharField(max_length=40, null=True, blank=True)
 
     class Meta:

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -6,11 +6,15 @@ import core.utils.samples
 import core.utils.schema
 
 
-def get_bio_analysis_stats_from_lab(lab_name=None):
+def get_bio_analysis_stats_from_lab(
+        lab_name=None,
+        institution_type="submitting_institution"
+    ):
     """Get the number of samples that are analized and compare with the number
     of recieved samples. If no lab name is given it matches all labs
     """
     bio_stats = {}
+    lab_query = {f"{institution_type}__iexact": lab_name}
     if lab_name is None:
         # get stats from all lab
         bioqry = core.models.DateUpdateState.objects.filter(
@@ -19,9 +23,7 @@ def get_bio_analysis_stats_from_lab(lab_name=None):
         bio_stats["analized"] = bioqry.values("sampleID").distinct().count()
         bio_stats["received"] = core.models.Sample.objects.count()
     else:
-        lab_samples = core.models.Sample.objects.filter(
-            submitting_institution__iexact=lab_name
-        )
+        lab_samples = core.models.Sample.objects.filter(**lab_query)
         bio_stats["analized"] = (
             core.models.DateUpdateState.objects.select_related("sampleID")
             .filter(sampleID__pk__in=lab_samples, stateID__state__iexact="Bioinfo")

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -7,9 +7,8 @@ import core.utils.schema
 
 
 def get_bio_analysis_stats_from_lab(
-        lab_name=None,
-        institution_type="submitting_institution"
-    ):
+    lab_name=None, institution_type="submitting_institution"
+):
     """Get the number of samples that are analized and compare with the number
     of recieved samples. If no lab name is given it matches all labs
     """

--- a/core/utils/samples_graphics.py
+++ b/core/utils/samples_graphics.py
@@ -45,7 +45,7 @@ def received_per_lab():
         samples_per_lab = dashboard.utils.generic_graphic_data.get_graphic_json_data(
             "samples_received_per_lab"
         )
-    return dashboard.utils.plotly.bar_graphic(
+    return core.utils.plotly_graphics.bar_graphic(
         data=samples_per_lab,
         col_names=["x", "y"],
         legend=[""],

--- a/core/views.py
+++ b/core/views.py
@@ -240,7 +240,7 @@ def intranet(request):
         user_group = request.user.groups.first()
         inst_map_fieldict = {
             "Submitter": "submitting_institution",
-            "Collector": "collecting_institution"
+            "Collector": "collecting_institution",
         }
         counted_dates = defaultdict(int)
         lab_field = inst_map_fieldict.get(user_group.name)

--- a/core/views.py
+++ b/core/views.py
@@ -237,10 +237,15 @@ def intranet(request):
         start = time.time()
         intra_data = {}
         lab_name = core.utils.labs.get_lab_name_from_user(request.user)
-
+        user_group = request.user.groups.first()
+        inst_map_fieldict = {
+            "Submitter": "submitting_institution",
+            "Collector": "collecting_institution"
+        }
         counted_dates = defaultdict(int)
+        lab_field = inst_map_fieldict.get(user_group.name)
         for d in all_sample_per_date_detailed:
-            if d["submitting_institution"] != lab_name:
+            if d[lab_field] != lab_name:
                 continue
             # Adapt YYYY-WNN to datetime format so it can be converted to date object
             converted_date = datetime.strptime(d["iso_yearweek"] + "-1", "%G-W%V-%u")
@@ -263,7 +268,9 @@ def intranet(request):
             sample_lab_objs = core.utils.samples.get_sample_objs_per_lab(lab_name)
             print(f"Took {start - time.time()} seconds for sample_lab_objs")
             analysis_percent = (
-                core.utils.bioinfo_analysis.get_bio_analysis_stats_from_lab(lab_name)
+                core.utils.bioinfo_analysis.get_bio_analysis_stats_from_lab(
+                    lab_name=lab_name, institution_type=lab_field
+                )
             )
             print(f"Took {start - time.time()} seconds for analysis_percent")
             cust_data = {


### PR DESCRIPTION
I implemented custom view of data depending on the user.group as it was only supported for users from a "submitting_institution". With these changes it supports two kinds of user groups: 

- Submitter: which will see all the samples with the same "submitting_institution" as its laboratory name,
- Collector: Whichi will see all the samples with the same "collecting_institution" as its labotaroty name.

I also adapted bioinfo_analysis percentage plot to also show the proper percentage of samples.

Finally, although it was not set as an issue, I included adaptive log scale in received_samples per lab plot as it was very difficult to see the laboratories with the least number of samples
