### PR TITLE
Cache Methodology charts – embed `met_index.py` outputs in `graphic_jsons`

### DIFF
--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -91,6 +91,8 @@ def update_graphic_json_data():
     dashboard.utils.generic_process_data.pre_proc_intranet_gisaid_data()
     print("Running pre_proc_intranet_ena_data()")
     dashboard.utils.generic_process_data.pre_proc_intranet_ena_data()
+    print("Running pre_proc_bioinfo_fields_util()")
+    dashboard.utils.generic_process_data.pre_proc_bioinfo_fields_util()
     uniq_chrom_id_list = [
         x["chromosomeID"]
         for x in core.models.Gene.objects.values("chromosomeID").distinct()

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -4,7 +4,6 @@ import json
 import logging
 from datetime import datetime
 from collections import OrderedDict, Counter, defaultdict
-from core.utils.bioinfo_analysis import get_bioinfo_analyis_fields_utilization
 from django.db.models import (
     F,
     Count,
@@ -24,6 +23,7 @@ import core.utils.variants
 import core.utils.rest_api
 import core.utils.generic_functions
 import core.utils.public_db
+import core.utils.bioinfo_analysis
 import dashboard.models
 import dashboard.dashboard_config
 import core.config
@@ -992,7 +992,9 @@ def pre_proc_bioinfo_fields_util():
     It calculates the utilization of bioinfo fields (Methodology)
     and saves it in GraphicJsonFile, just like the rest of the pre-processes.
     """
-    util_data = get_bioinfo_analyis_fields_utilization(use_cache=False)
+    util_data = core.utils.bioinfo_analysis.get_bioinfo_analysis_fields_utilization(
+        use_cache=False
+    )
 
     dashboard.models.GraphicJsonFile.objects.create_new_graphic_json(
         {

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -4,6 +4,7 @@ import json
 import logging
 from datetime import datetime
 from collections import OrderedDict, Counter, defaultdict
+from core.utils.bioinfo_analysis import get_bioinfo_analyis_fields_utilization
 from django.db.models import (
     F,
     Count,
@@ -981,6 +982,22 @@ def pre_proc_intranet_ena_data():
         {
             "graphic_name": "intranet_ena_data",
             "graphic_data": ena_data,
+        }
+    )
+    return {"SUCCESS": "Success"}
+
+
+def pre_proc_bioinfo_fields_util():
+    """
+    It calculates the utilization of bioinfo fields (Methodology)
+    and saves it in GraphicJsonFile, just like the rest of the pre-processes.
+    """
+    util_data = get_bioinfo_analyis_fields_utilization(use_cache=False)
+
+    dashboard.models.GraphicJsonFile.objects.create_new_graphic_json(
+        {
+            "graphic_name": "methodology_bioinfo_fields",
+            "graphic_data": util_data,
         }
     )
     return {"SUCCESS": "Success"}

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -1,4 +1,5 @@
 # Generic imports
+import json
 from statistics import mean
 
 # Local imports
@@ -8,6 +9,26 @@ import core.utils.samples
 import core.utils.schema
 import dashboard.dashboard_config
 import dashboard.utils.plotly
+from dashboard.models import GraphicJsonFile
+
+
+def _read_cached_bioinfo_util():
+    """
+    Returns the pre-baked JSON of bioinfo field usage,
+    or None if it does not yet exist.
+    """
+    try:
+        obj = GraphicJsonFile.objects.filter(
+            graphic_name="methodology_bioinfo_fields"
+        ).latest("creation_date")
+
+        data = obj.graphic_data
+        if isinstance(data, str):
+            data = json.loads(data)
+        return data
+
+    except GraphicJsonFile.DoesNotExist:
+        return None
 
 
 def schema_fields_utilization():
@@ -52,7 +73,10 @@ def schema_fields_utilization():
         util_data["num_lab_fields"] = len(lims_fields["fields_value"])
 
     # get fields utilization from bioinfo analysis
-    bio_fields = core.utils.bioinfo_analysis.get_bioinfo_analyis_fields_utilization()
+    bio_fields = (
+        _read_cached_bioinfo_util()
+        or core.utils.bioinfo_analysis.get_bioinfo_analyis_fields_utilization()
+    )
     # if return an empty value skip looking for data
     if not bool(bio_fields):
         util_data["ERROR_ANALYSIS"] = "Not Data to process"


### PR DESCRIPTION
## PR Description
This PR speeds up the Methodology section by pre-computing its charts and packaging them inside the `graphic_jsons` bundle instead of rendering them at runtime.