### PR TITLE
Fixing update laboratory contact html form

### DIFF
--- a/core/templates/core/laboratoryContact.html
+++ b/core/templates/core/laboratoryContact.html
@@ -45,78 +45,77 @@
                                             </div> <!-- end card body  -->
                                         </div> <!-- end card  -->
                                     </div> <!--// end col-sm-9 -->
-                            {% else %}
-                                <div class="row m-5">
-                                    <div class="col-sm-12" >
-                                        <div class="card  border-default mb-3">
-                                            <div class="card-header text-center">
-                                                <h3 style="text-align:center">You are logged in as staff of :</h3>
-                                                <h5 style="text-align:center">{{lab_data.lab_name}}</h5>
-                                            </div>
-                                            <div class="card-body  text-center">
-                                                <p>The recorded contact information is:</p>
-                                                <table class="table table-hover">
-                                                    <tr>
-                                                        <td>Contact Name</td>
-                                                        {% if lab_data.contact_name != "" %}
-                                                            <td>{{lab_data.lab_contact_name}}</td>
-                                                        {% else %}
-                                                            <td>Not Provided</td>
-                                                        {% endif %}
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Contact Telephone</td>
-                                                        {% if lab_data.contact_telephone != "" %}
-                                                            <td>{{lab_data.lab_contact_telephone}}</td>
-                                                        {% else %}
-                                                            <td>Not Provided</td>
-                                                        {% endif %}
-                                                    </tr>
-                                                    <tr>
-                                                        <td>Contact email</td>
-                                                        {% if lab_data.contact_email != "" %}
-                                                            <td>{{lab_data.lab_contact_email}}</td>
-                                                        {% else %}
-                                                            <td>Not Provided</td>
-                                                        {% endif %}
-                                                    </tr>
-                                                </table>
-                                            </div> <!-- end card body  -->
-                                        </div> <!-- end card  -->
-                                    </div> <!--// end col-sm-12 -->
-                                </div> <!--// end row -->
-                                <div class="row m-5">
-                                    <div class="col-sm-12">
-                                        <div class="card  border-default mb-3">
-                                            <div class="card-header text-center">
-                                                <h3 style="text-align:center">Use the form below to update your contact details</h3>
-                                            </div>
-                                            <div class="card-body  text-center">
-                                                <form class="row g-3"  method="post"  enctype="multipart/form-data" name="updateLabData"  id="updateLabData" class="form-horizontal well" style="min-height: 100px;">
-                                                    {% csrf_token %}
-                                                    <input type="hidden" name="action" value="updateLabData">
-                                                    <input type="hidden" name="lab_name" value="{{lab_data.lab_name}}">
-                                                    <div class="form-floating mb-3">
-                                                        <input type="text" class="form-control" id="floatingInput" name="lab_contact_name" placeholder="lab_contact_name">
-                                                        <label for="floatingInput">Update contact name</label>
-                                                    </div>
-                                                    <div class="form-floating mb-3">
-                                                        <input type="text" class="form-control" id="floatingInput" name="lab_contact_telephone" placeholder="lab_contact_telephone">
-                                                        <label for="floatingInput">Update phone number contact</label>
-                                                    </div>
-                                                    <div class="form-floating mb-3">
-                                                        <input type="text" class="form-control" id="floatingInput" name="lab_contact_email" placeholder="lab_contact_email">
-                                                        <label for="floatingInput">Update email contact</label>
-                                                    </div>
-                                                    <div class="col-auto">
-                                                        <button type="submit" class="btn btn-primary mb-3">Submit Info</button>
-                                                    </div>
-                                                </form>
-                                            </div> <!-- end card body  -->
-                                        </div> <!-- end card  -->
-                                    </div> <!--// end col-sm-12 -->
-                                </div> <!--// end row -->
                             {% endif %}
+                            <div class="row m-5">
+                                <div class="col-sm-12" >
+                                    <div class="card  border-default mb-3">
+                                        <div class="card-header text-center">
+                                            <h3 style="text-align:center">You are logged in as staff of :</h3>
+                                            <h5 style="text-align:center">{{lab_data.lab_name}}</h5>
+                                        </div>
+                                        <div class="card-body  text-center">
+                                            <p>The recorded contact information is:</p>
+                                            <table class="table table-hover">
+                                                <tr>
+                                                    <td>Contact Name</td>
+                                                    {% if lab_data.lab_contact_name != "" %}
+                                                        <td>{{lab_data.lab_contact_name}}</td>
+                                                    {% else %}
+                                                        <td>Not Provided</td>
+                                                    {% endif %}
+                                                </tr>
+                                                <tr>
+                                                    <td>Contact Telephone</td>
+                                                    {% if lab_data.lab_phone != "" %}
+                                                        <td>{{lab_data.lab_phone}}</td>
+                                                    {% else %}
+                                                        <td>Not Provided</td>
+                                                    {% endif %}
+                                                </tr>
+                                                <tr>
+                                                    <td>Contact email</td>
+                                                    {% if lab_data.lab_email != "" %}
+                                                        <td>{{lab_data.lab_email}}</td>
+                                                    {% else %}
+                                                        <td>Not Provided</td>
+                                                    {% endif %}
+                                                </tr>
+                                            </table>
+                                        </div> <!-- end card body  -->
+                                    </div> <!-- end card  -->
+                                </div> <!--// end col-sm-12 -->
+                            </div> <!--// end row -->
+                            <div class="row m-5">
+                                <div class="col-sm-12">
+                                    <div class="card  border-default mb-3">
+                                        <div class="card-header text-center">
+                                            <h3 style="text-align:center">Use the form below to update your contact details</h3>
+                                        </div>
+                                        <div class="card-body  text-center">
+                                            <form class="row g-3"  method="post"  enctype="multipart/form-data" name="updateLabData"  id="updateLabData" class="form-horizontal well" style="min-height: 100px;">
+                                                {% csrf_token %}
+                                                <input type="hidden" name="action" value="updateLabData">
+                                                <input type="hidden" name="lab_name" value="{{lab_data.lab_name}}">
+                                                <div class="form-floating mb-3">
+                                                    <input type="text" class="form-control" id="floatingInput" name="lab_contact_name" placeholder="lab_contact_name">
+                                                    <label for="floatingInput">Update contact name</label>
+                                                </div>
+                                                <div class="form-floating mb-3">
+                                                    <input type="text" class="form-control" id="floatingInput" name="lab_phone" placeholder="lab_phone">
+                                                    <label for="floatingInput">Update phone number contact</label>
+                                                </div>
+                                                <div class="form-floating mb-3">
+                                                    <input type="text" class="form-control" id="floatingInput" name="lab_email" placeholder="lab_email">
+                                                    <label for="floatingInput">Update email contact</label>
+                                                </div>
+                                                <div class="col-auto">
+                                                    <button type="submit" class="btn btn-primary mb-3">Submit Info</button>
+                                                </div>
+                                            </form>
+                                        </div> <!-- end card body  -->
+                                    </div> <!-- end card  -->
+                                </div> <!--// end col-sm-12 -->
+                            </div> <!--// end row -->
                         </div>   <!-- end row -->
                     </div> <!-- /.container-fluid -->
                 </div> <!-- End of Main Content -->

--- a/core/utils/labs.py
+++ b/core/utils/labs.py
@@ -47,25 +47,16 @@ def get_collecting_insts_from_lab(lab_name):
     )
 
 
-def update_contact_lab(old_data, new_data):
+def update_contact_lab(data):
     """Update the contact information. If any field is empty it will set the
     old value. In case that all new_data are empty returns than no changes
+
+    Expected fields:
+        - lab_name
+        - lab_contact_name
+        - lab_phone
+        - lab_email
     """
-    # TODO: Improve this. There is an inconsistency between GET and POST data when APIs communicate.
-    key_mapping = {
-        "Lab email": "lab_contact_email",
-        "Lab phone": "lab_contact_telephone",
-        "Lab contact name": "lab_contact_name",
-        "Lab name": "lab_name",
-    }
-
-    data = {}
-
-    for old_key, new_key in key_mapping.items():
-        # Obtiene el nuevo valor, si está vacío usa el valor viejo
-        new_value = new_data.get(new_key, "").strip()
-        data[new_key] = old_data.get(old_key, "") if new_value == "" else new_value
-
     result = core.utils.rest_api.set_laboratory_data(data)
     if "ERROR" in result:
         return result

--- a/core/views.py
+++ b/core/views.py
@@ -559,7 +559,7 @@ def laboratory_contact(request):
             request,
             "core/laboratoryContact.html",
             {
-                "ERROR": f"{lab_data["ERROR"]} : No contact data found for your laboratory {user_lab}",
+                "ERROR": f"{lab_data['ERROR']} : No contact data found for your laboratory {user_lab}",
                 "lab_data": proc_lab_data,
             },
         )

--- a/core/views.py
+++ b/core/views.py
@@ -552,22 +552,27 @@ def organism_annotation(request):
 @login_required()
 def laboratory_contact(request):
     lab_data = core.utils.labs.get_lab_contact_details(request.user)
+    user_lab = core.utils.labs.get_lab_name_from_user(request.user)
+    proc_lab_data = {k.replace(" ", "_").lower(): v for k, v in lab_data.items()}
     if "ERROR" in lab_data:
         return render(
-            request, "core/laboratoryContact.html", {"ERROR": lab_data["ERROR"]}
+            request,
+            "core/laboratoryContact.html",
+            {
+                "ERROR": f"{lab_data["ERROR"]} : No contact data found for your laboratory {user_lab}",
+                "lab_data": proc_lab_data,
+            },
         )
     if request.method == "POST" and request.POST["action"] == "updateLabData":
-        result = core.utils.labs.update_contact_lab(
-            old_data=lab_data, new_data=request.POST
-        )
+        result = core.utils.labs.update_contact_lab(request.POST)
         if isinstance(result, dict):
-            return render(
-                request,
-                "core/laboratoryContact.html",
-                {"ERROR": result["ERROR"]},
-            )
+            errdict = {
+                "ERROR": f"{result['ERROR']} - Could not update your contact details",
+                "lab_data": proc_lab_data,
+            }
+            return render(request, "core/laboratoryContact.html", errdict)
         return render(request, "core/laboratoryContact.html", {"Success": "Success"})
-    return render(request, "core/laboratoryContact.html", {"lab_data": lab_data})
+    return render(request, "core/laboratoryContact.html", {"lab_data": proc_lab_data})
 
 
 @login_required


### PR DESCRIPTION
This PR implements two changes to intranet/LaboratoryContact.html

1. The form to update contact data can be filled right away after error, as it can now be seen after the error.
2. The placeholders are fixed to return the POST request keys with the correct names, so the update method does not need any key mapping now.