### PR TITLE
Only show dash_bar_for_each_lab if user has more than 1 lab

### DIFF
--- a/core/templates/core/intranet.html
+++ b/core/templates/core/intranet.html
@@ -291,11 +291,13 @@
                                                                     {{ intra_data.sample_gauge_graph | safe }}
                                                                 </div>
                                                             </div> <!-- end col-md-5 -->
+                                                            {% if intra_data.show_per_lab_dash %}
                                                             <div class="col-md-12">
                                                                 <div style="max-width: 100%; overflow-x: auto;">
                                                                     {% plotly_app name="samplePerLabGraphic" ratio=1 %}
                                                                 </div>
                                                             </div> <!-- end col-md-7 -->
+                                                            {% endif %}
                                                         {% else %}
                                                             <div class="col-md-7">
                                                                 <div class="card border-warning mb-3">

--- a/core/views.py
+++ b/core/views.py
@@ -268,9 +268,13 @@ def intranet(request):
             lablist = set(
                 [x["collecting_institution"] for x in clean_samples_per_date_detailed]
             )
-            core.utils.samples.create_dash_bar_for_each_lab(
-                clean_samples_per_date_detailed, lablist
-            )
+            if len(lablist) > 1:
+                core.utils.samples.create_dash_bar_for_each_lab(
+                    clean_samples_per_date_detailed, lablist
+                )
+                intra_data["show_per_lab_dash"] = True
+            else:
+                intra_data["show_per_lab_dash"] = False
             print(f"Took {start - time.time()} seconds for gauge_graph")
             intra_data["actions"] = core.utils.samples.get_lab_last_actions(lab_name)
             gisaid_acc = core.utils.public_db.get_preprocessed_gisaid_data()


### PR DESCRIPTION
Intranet was showing duplicate info when user had only one lab to see, as the main plot and the secondary dash_bar plot showed the same information