### PR TITLE
Replace empty `library_preparation_kit` values with `“Not Applicable”`

### DIFF
--- a/dashboard/utils/met_sequencing.py
+++ b/dashboard/utils/met_sequencing.py
@@ -124,6 +124,13 @@ def sequencing_graphics():
         project_field="library_preparation_kit",
         columns=["library_preparation", "number"],
     )
+    lib_preparation_df["library_preparation"] = (
+        lib_preparation_df["library_preparation"]
+        .fillna("")
+        .astype(str)
+        .str.strip()
+        .replace({"": "Not Applicable"})
+    )
     sequencing["library_preparation"] = dashboard.utils.plotly.bar_graphic(
         data=lib_preparation_df,
         col_names=["library_preparation", "number"],


### PR DESCRIPTION
## PR Description
This PR standardises the `library_preparation_kit` field across all metadata-processing modules.

What’s changed?
Empty or blank `library_preparation_kit` values ("") are now replaced with the placeholder: `Not Applicable`