### PR TITLE
added custom prefix to unique sample id generation

### DIFF
--- a/core/api/utils/samples.py
+++ b/core/api/utils/samples.py
@@ -70,5 +70,5 @@ def split_sample_data(data):
             core.utils.samples.increase_unique_value(last_unique_value)
         )
     else:
-        split_data["sample"]["sample_unique_id"] = "AAA-0001"
+        split_data["sample"]["sample_unique_id"] = core.config.SAMPLE_ID_PREFIX + "AAA-0001"
     return split_data

--- a/core/api/utils/samples.py
+++ b/core/api/utils/samples.py
@@ -70,5 +70,7 @@ def split_sample_data(data):
             core.utils.samples.increase_unique_value(last_unique_value)
         )
     else:
-        split_data["sample"]["sample_unique_id"] = core.config.SAMPLE_ID_PREFIX + "AAA-0001"
+        split_data["sample"]["sample_unique_id"] = (
+            core.config.SAMPLE_ID_PREFIX + "AAA-0001"
+        )
     return split_data

--- a/core/config.py
+++ b/core/config.py
@@ -1,3 +1,5 @@
+SAMPLE_ID_PREFIX = "RL-"
+
 ALLOWED_EMPTY_FIELDS_IN_METADATA_SAMPLE_FORM = [
     "Public Health sample id (SIVIES)",
     "GISAID id",

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -732,12 +732,12 @@ def increase_unique_value(old_unique_number):
     If number reaches the 9999 then the letter is stepped
     """
     split_value = old_unique_number.split("-")
-    number = int(split_value[1]) + 1
-    letter = split_value[0]
+    number = int(split_value[2]) + 1
+    letter = split_value[1]
 
     if number > 9999:
         number = 1
-        index_letter = list(split_value[0])
+        index_letter = list(split_value[1])
         if index_letter[2] == "Z":
             if index_letter[1] == "Z":
                 index_letter[0] = chr(ord(index_letter[0]) + 1)
@@ -755,7 +755,7 @@ def increase_unique_value(old_unique_number):
 
     number_str = str(number)
     number_str = number_str.zfill(4)
-    return str(letter + "-" + number_str)
+    return str(core.config.SAMPLE_ID_PREFIX + letter + "-" + number_str)
 
 
 def pending_samples_in_metadata_form(user_obj):


### PR DESCRIPTION
Closes #348 

- Relecov unique_sample_id is going to be used as sample name in iskylims. iskylims has its own unique_sample_id, so i've added RL- to relecov id to avoid confusion.