### PR TITLE
Fixing host_info plot and wrong number of not-provided samples in it

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -102,6 +102,7 @@ FIELD_EMPTY_VALUES = [
     "None",
     "Not Provided",
     "Not Applicable",
+    "Not Applicable [GENEPIO:0001619]",
     "Not Collected",
     "Not Provided [SNOMED:434941000124101]",
     "Not Provided [GENEPIO:0001668]",

--- a/core/config.py
+++ b/core/config.py
@@ -106,6 +106,7 @@ FIELD_EMPTY_VALUES = [
     "Not Collected",
     "Not Provided [SNOMED:434941000124101]",
     "Not Provided [GENEPIO:0001668]",
+    "Missing",
 ]
 
 MAIN_SCHEMA_STRUCTURE = ["$schema", "required", "type", "properties"]

--- a/dashboard/utils/generic_process_data.py
+++ b/dashboard/utils/generic_process_data.py
@@ -671,6 +671,7 @@ def pre_proc_host_info():
                     for k in set(years_fields[invalid_key])
                     | set(years_fields.get("Not Provided", {}))
                 }
+            if invalid_key != "Not Provided":
                 del years_fields[invalid_key]
         for key, values in years_fields.items():
             tmp_range_per_key[key], tmp_invalid_data = split_age_in_ranges(values)


### PR DESCRIPTION
This PR fixes "Not Provided" label not being shown due to new entries of more labels, along with fixing the true number of "Not Provided" samples within that plot, as it was being understimated (8k were missing)