### PR TITLE
Hotfix for admin form to edit schemas

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -152,13 +152,16 @@ class SchemaAdminForm(forms.ModelForm):
         if self.instance and self.instance.file_name:
             path = self.instance.file_name.path
             if os.path.exists(path):
-                with open(path, "r") as f:
+                if self.instance and self.instance.file_name:
+                    f = self.instance.file_name
                     try:
-                        self.fields["json_content"].initial = json.dumps(
-                            json.load(f), indent=2
-                        )
+                        f.open()  # opens file in storage backend
+                        self.fields["json_content"].initial = f.read().decode("utf-8")
+                        f.close()
                     except Exception:
-                        self.fields["json_content"].initial = f.read()
+                        self.fields["json_content"].initial = ""
+            else:
+                print(f"Schema file does not exist: {path}")
 
     def save(self, commit=True):
         instance = super().save(commit=False)

--- a/core/admin.py
+++ b/core/admin.py
@@ -3,7 +3,6 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 from django import forms
-import json
 import os
 
 # Local imports


### PR DESCRIPTION
Last PR included this new form, which worked perfectly locally, but does not work fine in production due to apache. Therefore, this PR includes an open+read workaround to edit the schema content successfully.