### PR TITLE
Remove `UniqueConstraint` from `core/models.py`

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -102,12 +102,6 @@ class Schema(models.Model):
 
     class Meta:
         db_table = "core_metadata_schema"
-        constraints = [
-            models.UniqueConstraint(
-                fields=["schema_name", "schema_version", "schema_apps_name"],
-                name="uniq_schema_name_version_app",
-            )
-        ]
 
     def __str__(self):
         return "%s_%s" % (self.schema_name, self.schema_version)


### PR DESCRIPTION
## PR Description
The constraint has been removed because it does not work as expected. It creates indexes in all related tables.