### PR TITLE
Fix `Analysis Performed` count method in `samples.py`

### DIFF
--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -100,6 +100,15 @@ def count_handled_samples():
         .annotate(count=Count("id"))
     )
     data = {entry["stateID__state"]: entry["count"] for entry in counted_data}
+    # Replace Bioinfo count with the number of recorded analyses (one per run)
+    bio_runs = core.models.BioinfoAnalysisValue.objects.filter(
+        bioinfo_analysis_fieldID__property_name__iexact="bioinformatics_analysis_date",
+        sample__isnull=False,
+    ).count()
+    data["Bioinfo"] = bio_runs
+    # Ensure all expected keys exist so dashboards don't get missing dict entries
+    for state in process:
+        data.setdefault(state, 0)
     return data
 
 


### PR DESCRIPTION
## PR Description
Previously, the count of analyses performed was based on the number of times an analysis had been uploaded. However, it did not take into account whether that same analysis had already been uploaded for that same sample. Thus, if a sample already has a bioinformatic_analysis_date, it will not be added to the overall count.