### PR TITLE
Submit Long-table by `unique_sample_id`, faster `variantdata` ingestion, and clarify field-utilization (`always_none` vs `never_used`) metrics

### DIFF
--- a/core/api/utils/samples.py
+++ b/core/api/utils/samples.py
@@ -29,6 +29,7 @@ def split_sample_data(data):
     """Split the json request into dictionnaries with the right fields"""
     ALIASES = {
         "collecting_institution_code_1": "lab_code_1",
+        "unique_sample_id": "sample_unique_id",
     }
     split_data = {"sample": {}, "author": {}, "gisaid": {}, "ena": {}}
 
@@ -69,7 +70,12 @@ def split_sample_data(data):
             split_data["sample"]["submitting_institution"]
         )
     )
-    if core.models.Sample.objects.all().exists():
+    requested_unique_id = str(
+        split_data["sample"].get("sample_unique_id") or ""
+    ).strip()
+    if requested_unique_id:
+        split_data["sample"]["sample_unique_id"] = requested_unique_id
+    elif core.models.Sample.objects.all().exists():
         last_unique_value = core.models.Sample.objects.all().last().get_unique_id()
         split_data["sample"]["sample_unique_id"] = (
             core.utils.samples.increase_unique_value(last_unique_value)

--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -1,32 +1,121 @@
+# Standard library imports
+from typing import Optional
+
 # Local imports
+
 import core.models
 import core.utils.variants
 import core.api.serializers
 import core.config
 
 
-def create_or_get_filter_obj(filter_value):
+class VariantProcessingCache:
+    """
+    Lightweight cache to avoid repeated lookups and creations while processing
+    the variants payload of a single request.
+    """
+
+    def __init__(self):
+        self.filters = {}
+        self.effects = {}
+        self.chromosomes = {}
+        self.genes = {}
+        self.variants = {}
+        self.variant_annotations = set()
+
+    @staticmethod
+    def _norm(value: Optional[str]) -> str:
+        return value.casefold() if isinstance(value, str) else ""
+
+    def cache_filter(self, value: str, obj: core.models.Filter) -> None:
+        self.filters[self._norm(value)] = obj
+
+    def get_filter(self, value: str):
+        return self.filters.get(self._norm(value))
+
+    def cache_effect(self, value: str, obj: core.models.Effect) -> None:
+        self.effects[self._norm(value)] = obj
+
+    def get_effect(self, value: str):
+        return self.effects.get(self._norm(value))
+
+    def cache_chrom(self, value: str, obj: core.models.Chromosome) -> None:
+        self.chromosomes[self._norm(value)] = obj
+
+    def get_chrom(self, value: str):
+        return self.chromosomes.get(self._norm(value))
+
+    def cache_gene(self, value: str, obj: core.models.Gene) -> None:
+        self.genes[self._norm(value)] = obj
+
+    def get_gene(self, value: str):
+        return self.genes.get(self._norm(value))
+
+    def cache_variant(self, chrom: str, pos: str, ref: str, alt: str, variant_id: int):
+        key = (self._norm(chrom), pos, self._norm(ref), self._norm(alt))
+        self.variants[key] = variant_id
+
+    def get_variant(self, chrom: str, pos: str, ref: str, alt: str):
+        key = (self._norm(chrom), pos, self._norm(ref), self._norm(alt))
+        return self.variants.get(key)
+
+    def has_annotation(self, hgvs_c: str, hgvs_p: str, hgvs_p1: str) -> bool:
+        key = (
+            self._norm(hgvs_c),
+            self._norm(hgvs_p),
+            self._norm(hgvs_p1),
+        )
+        return key in self.variant_annotations
+
+    def cache_annotation(self, hgvs_c: str, hgvs_p: str, hgvs_p1: str) -> None:
+        key = (
+            self._norm(hgvs_c),
+            self._norm(hgvs_p),
+            self._norm(hgvs_p1),
+        )
+        self.variant_annotations.add(key)
+
+
+def create_or_get_filter_obj(filter_value, cache=None):
     """Return the filter instance or create if not exists"""
-    if core.models.Filter.objects.filter(filter__iexact=filter_value).exists():
-        return core.models.Filter.objects.filter(filter__iexact=filter_value).last()
+    if cache:
+        cached = cache.get_filter(filter_value)
+        if cached:
+            return cached
+    filter_obj = core.models.Filter.objects.filter(filter__iexact=filter_value).last()
+    if filter_obj:
+        if cache:
+            cache.cache_filter(filter_value, filter_obj)
+        return filter_obj
     filter_serializer = core.api.serializers.CreateFilterSerializer(
         data={"filter": filter_value}
     )
     if filter_serializer.is_valid():
         filter_obj = filter_serializer.save()
+        if cache:
+            cache.cache_filter(filter_value, filter_obj)
         return filter_obj
     return {"ERROR": core.config.ERROR_UNABLE_TO_STORE_IN_DATABASE}
 
 
-def create_or_get_effect_obj(effect_value):
+def create_or_get_effect_obj(effect_value, cache=None):
     """Return the effect instance or create if not exists"""
-    if core.models.Effect.objects.filter(effect__iexact=effect_value).exists():
-        return core.models.Effect.objects.filter(effect__iexact=effect_value).last()
+    if cache:
+        cached = cache.get_effect(effect_value)
+        if cached:
+            return cached
+    effect_obj = core.models.Effect.objects.filter(effect__iexact=effect_value).last()
+    if effect_obj:
+        if cache:
+            cache.cache_effect(effect_value, effect_obj)
+        return effect_obj
     effect_serializer = core.api.serializers.CreateEffectSerializer(
         data={"effect": effect_value}
     )
     if effect_serializer.is_valid():
         effect_obj = effect_serializer.save()
+        if cache:
+            cache.cache_effect(effect_value, effect_obj)
         return effect_obj
 
     return {"ERROR": core.config.ERROR_UNABLE_TO_STORE_IN_DATABASE}
@@ -40,13 +129,19 @@ def delete_created_variancs(v_in_sample_list, v_an_list):
     return
 
 
-def store_variant_annotation(v_ann_data):
+def store_variant_annotation(v_ann_data, cache=None):
     v_ann_serializer = core.api.serializers.CreateVariantAnnotationSerializer(
         data=v_ann_data
     )
     if not v_ann_serializer.is_valid():
         return {"ERROR": core.config.ERROR_UNABLE_TO_STORE_IN_DATABASE}
     v_ann_obj = v_ann_serializer.save()
+    if cache:
+        cache.cache_annotation(
+            v_ann_data.get("hgvs_c"),
+            v_ann_data.get("hgvs_p"),
+            v_ann_data.get("hgvs_p_1_letter"),
+        )
     return v_ann_obj
 
 
@@ -60,25 +155,38 @@ def store_variant_in_sample(v_data):
     return v_obj
 
 
-def get_variant_id(data):
+def get_variant_id(data, cache=None):
     """look out for the necessary reference ids to create the variance instance"""
-    chr_obj = core.utils.variants.get_if_chromosomes_exists(data["chromosome"])
+    chromosome = data["chromosome"]
+    chr_obj = cache.get_chrom(chromosome) if cache else None
+    if chr_obj is None:
+        chr_obj = core.utils.variants.get_if_chromosomes_exists(chromosome)
+        if cache and chr_obj:
+            cache.cache_chrom(chromosome, chr_obj)
     if chr_obj is None:
         return {"ERROR": core.config.ERROR_CHROMOSOME_NOT_DEFINED_IN_DATABASE}
+
+    pos = str(data["pos"])
+    ref = data["ref"]
+    alt = data["alt"]
+
+    if cache:
+        cached_variant_id = cache.get_variant(chromosome, pos, ref, alt)
+        if cached_variant_id:
+            return cached_variant_id
+
     variant_obj = core.models.Variant.objects.filter(
-        chromosomeID_id=chr_obj,
-        pos__iexact=data["pos"],
-        alt__iexact=data["alt"],
+        chromosomeID_id=chr_obj, pos__iexact=pos, alt__iexact=alt
     ).last()
     if variant_obj is None:
         # Create the variant
-        filter_obj = create_or_get_filter_obj(data["Filter"])
+        filter_obj = create_or_get_filter_obj(data["Filter"], cache=cache)
         if isinstance(filter_obj, dict):
             return filter_obj
         variant_dict = {}
         variant_dict["chromosomeID_id"] = chr_obj.get_chromosome_id()
         variant_dict["filterID_id"] = filter_obj.get_filter_id()
-        variant_dict["pos"] = data["pos"]
+        variant_dict["pos"] = pos
         variant_dict["alt"] = data["alt"]
         variant_dict["ref"] = data["ref"]
         variant_serializer = core.api.serializers.CreateVariantSerializer(
@@ -87,7 +195,10 @@ def get_variant_id(data):
         if not variant_serializer.is_valid():
             return {"ERROR": core.config.ERROR_UNABLE_TO_STORE_IN_DATABASE}
         variant_obj = variant_serializer.save()
-    return variant_obj.get_variant_id()
+    variant_id = variant_obj.get_variant_id()
+    if cache:
+        cache.cache_variant(chromosome, pos, ref, alt, variant_id)
+    return variant_id
 
 
 def get_variant_analysis_defined(s_obj):
@@ -96,15 +207,20 @@ def get_variant_analysis_defined(s_obj):
     )
 
 
-def get_required_variant_ann_id(data):
+def get_required_variant_ann_id(data, cache=None):
     """Look for the ids that variant annotation needs"""
     v_ann_ids = {}
-    gene_obj = core.utils.variants.get_gene_obj_from_gene_name(data["gene"])
+    gene_name = data["gene"]
+    gene_obj = cache.get_gene(gene_name) if cache else None
+    if gene_obj is None:
+        gene_obj = core.utils.variants.get_gene_obj_from_gene_name(gene_name)
+        if cache and gene_obj:
+            cache.cache_gene(gene_name, gene_obj)
 
     if gene_obj is None:
         return {"ERROR": core.config.ERROR_GENE_NOT_DEFINED_IN_DATABASE}
     v_ann_ids["geneID_id"] = gene_obj.get_gene_id()
-    effect_obj = create_or_get_effect_obj(data["effect"])
+    effect_obj = create_or_get_effect_obj(data["effect"], cache=cache)
     if isinstance(effect_obj, dict):
         return effect_obj
     v_ann_ids["geneID_id"] = gene_obj.get_gene_id()
@@ -112,22 +228,22 @@ def get_required_variant_ann_id(data):
     return v_ann_ids
 
 
-def split_variant_data(data, sample_obj, date):
+def split_variant_data(data, sample_obj, date, cache=None):
     """Separate the information received into groups"""
     split_data = {"variant_in_sample": {}, "variant_ann": {}}
     split_data["variant_in_sample"]["sampleID_id"] = sample_obj.get_sample_id()
 
-    variant_id = get_variant_id(data)
+    variant_id = get_variant_id(data, cache=cache)
     if isinstance(variant_id, dict):
         return variant_id
     split_data["variant_in_sample"]["variantID_id"] = variant_id
-    split_data["variant_in_sample"]["analysis_date"] = date
+    split_data["variant_in_sample"]["bioinformatics_analysis_date"] = date
 
     var_keys = ["dp", "ref_dp", "alt_dp", "af"]
     data["VariantInSample"] = {x: y for x, y in data.items() if x in var_keys}
     split_data["variant_in_sample"].update(data["VariantInSample"])
 
-    v_ann_id = get_required_variant_ann_id(data)
+    v_ann_id = get_required_variant_ann_id(data, cache=cache)
     if "ERROR" in v_ann_id:
         return v_ann_id
     split_data["variant_ann"] = v_ann_id
@@ -139,12 +255,18 @@ def split_variant_data(data, sample_obj, date):
     return split_data
 
 
-def variant_annotation_exists(data):
+def variant_annotation_exists(data, cache=None):
     """Check if variant annotation exists. Return True if exists"""
-    if core.models.VariantAnnotation.objects.filter(
-        hgvs_c__iexact=data["hgvs_c"],
-        hgvs_p__iexact=data["hgvs_p"],
-        hgvs_p_1_letter__iexact=data["hgvs_p_1_letter"],
-    ).exists():
+    hgvs_c = data.get("hgvs_c")
+    hgvs_p = data.get("hgvs_p")
+    hgvs_p1 = data.get("hgvs_p_1_letter")
+    if cache and cache.has_annotation(hgvs_c, hgvs_p, hgvs_p1):
         return True
-    return False
+    exists = core.models.VariantAnnotation.objects.filter(
+        hgvs_c__iexact=hgvs_c,
+        hgvs_p__iexact=hgvs_p,
+        hgvs_p_1_letter__iexact=hgvs_p1,
+    ).exists()
+    if exists and cache:
+        cache.cache_annotation(hgvs_c, hgvs_p, hgvs_p1)
+    return exists

--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -16,27 +16,27 @@ class VariantProcessingCache:
     """
 
     def __init__(self):
-        self.filters = {}
-        self.effects = {}
+        self.filters: dict[str, int] = {}
+        self.effects: dict[str, int] = {}
         self.chromosomes = {}
-        self.genes = {}
-        self.variants = {}
-        self.variant_annotations = set()
+        self.genes: dict[str, int] = {}
+        self.variants: dict[tuple[str, str, str, str], int] = {}
+        self.variant_annotations: set[tuple[str, str, str]] = set()
 
     @staticmethod
     def _norm(value: Optional[str]) -> str:
         return value.casefold() if isinstance(value, str) else ""
 
-    def cache_filter(self, value: str, obj: core.models.Filter) -> None:
-        self.filters[self._norm(value)] = obj
+    def cache_filter(self, value: str, obj_id: int) -> None:
+        self.filters[self._norm(value)] = obj_id
 
-    def get_filter(self, value: str):
+    def get_filter(self, value: str) -> Optional[int]:
         return self.filters.get(self._norm(value))
 
-    def cache_effect(self, value: str, obj: core.models.Effect) -> None:
-        self.effects[self._norm(value)] = obj
+    def cache_effect(self, value: str, obj_id: int) -> None:
+        self.effects[self._norm(value)] = obj_id
 
-    def get_effect(self, value: str):
+    def get_effect(self, value: str) -> Optional[int]:
         return self.effects.get(self._norm(value))
 
     def cache_chrom(self, value: str, obj: core.models.Chromosome) -> None:
@@ -45,10 +45,10 @@ class VariantProcessingCache:
     def get_chrom(self, value: str):
         return self.chromosomes.get(self._norm(value))
 
-    def cache_gene(self, value: str, obj: core.models.Gene) -> None:
-        self.genes[self._norm(value)] = obj
+    def cache_gene(self, value: str, obj_id: int) -> None:
+        self.genes[self._norm(value)] = obj_id
 
-    def get_gene(self, value: str):
+    def get_gene(self, value: str) -> Optional[int]:
         return self.genes.get(self._norm(value))
 
     def cache_variant(self, chrom: str, pos: str, ref: str, alt: str, variant_id: int):
@@ -75,48 +75,56 @@ class VariantProcessingCache:
         )
         self.variant_annotations.add(key)
 
+    def reset(self) -> None:
+        self.filters.clear()
+        self.effects.clear()
+        self.chromosomes.clear()
+        self.genes.clear()
+        self.variants.clear()
+        self.variant_annotations.clear()
+
 
 def create_or_get_filter_obj(filter_value, cache=None):
     """Return the filter instance or create if not exists"""
     if cache:
-        cached = cache.get_filter(filter_value)
-        if cached:
-            return cached
+        cached_id = cache.get_filter(filter_value)
+        if cached_id:
+            return cached_id
     filter_obj = core.models.Filter.objects.filter(filter__iexact=filter_value).last()
     if filter_obj:
         if cache:
-            cache.cache_filter(filter_value, filter_obj)
-        return filter_obj
+            cache.cache_filter(filter_value, filter_obj.pk)
+        return filter_obj.pk
     filter_serializer = core.api.serializers.CreateFilterSerializer(
         data={"filter": filter_value}
     )
     if filter_serializer.is_valid():
         filter_obj = filter_serializer.save()
         if cache:
-            cache.cache_filter(filter_value, filter_obj)
-        return filter_obj
+            cache.cache_filter(filter_value, filter_obj.pk)
+        return filter_obj.pk
     return {"ERROR": core.config.ERROR_UNABLE_TO_STORE_IN_DATABASE}
 
 
 def create_or_get_effect_obj(effect_value, cache=None):
     """Return the effect instance or create if not exists"""
     if cache:
-        cached = cache.get_effect(effect_value)
-        if cached:
-            return cached
+        cached_id = cache.get_effect(effect_value)
+        if cached_id:
+            return cached_id
     effect_obj = core.models.Effect.objects.filter(effect__iexact=effect_value).last()
     if effect_obj:
         if cache:
-            cache.cache_effect(effect_value, effect_obj)
-        return effect_obj
+            cache.cache_effect(effect_value, effect_obj.pk)
+        return effect_obj.pk
     effect_serializer = core.api.serializers.CreateEffectSerializer(
         data={"effect": effect_value}
     )
     if effect_serializer.is_valid():
         effect_obj = effect_serializer.save()
         if cache:
-            cache.cache_effect(effect_value, effect_obj)
-        return effect_obj
+            cache.cache_effect(effect_value, effect_obj.pk)
+        return effect_obj.pk
 
     return {"ERROR": core.config.ERROR_UNABLE_TO_STORE_IN_DATABASE}
 
@@ -180,12 +188,12 @@ def get_variant_id(data, cache=None):
     ).last()
     if variant_obj is None:
         # Create the variant
-        filter_obj = create_or_get_filter_obj(data["Filter"], cache=cache)
-        if isinstance(filter_obj, dict):
-            return filter_obj
+        filter_id = create_or_get_filter_obj(data["Filter"], cache=cache)
+        if isinstance(filter_id, dict):
+            return filter_id
         variant_dict = {}
         variant_dict["chromosomeID_id"] = chr_obj.get_chromosome_id()
-        variant_dict["filterID_id"] = filter_obj.get_filter_id()
+        variant_dict["filterID_id"] = filter_id
         variant_dict["pos"] = pos
         variant_dict["alt"] = data["alt"]
         variant_dict["ref"] = data["ref"]
@@ -195,7 +203,7 @@ def get_variant_id(data, cache=None):
         if not variant_serializer.is_valid():
             return {"ERROR": core.config.ERROR_UNABLE_TO_STORE_IN_DATABASE}
         variant_obj = variant_serializer.save()
-    variant_id = variant_obj.get_variant_id()
+    variant_id = variant_obj.pk
     if cache:
         cache.cache_variant(chromosome, pos, ref, alt, variant_id)
     return variant_id
@@ -211,20 +219,21 @@ def get_required_variant_ann_id(data, cache=None):
     """Look for the ids that variant annotation needs"""
     v_ann_ids = {}
     gene_name = data["gene"]
-    gene_obj = cache.get_gene(gene_name) if cache else None
-    if gene_obj is None:
+    gene_id = cache.get_gene(gene_name) if cache else None
+    if gene_id is None:
         gene_obj = core.utils.variants.get_gene_obj_from_gene_name(gene_name)
-        if cache and gene_obj:
-            cache.cache_gene(gene_name, gene_obj)
+        if gene_obj is None:
+            return {"ERROR": core.config.ERROR_GENE_NOT_DEFINED_IN_DATABASE}
+        gene_id = gene_obj.get_gene_id()
+        if cache:
+            cache.cache_gene(gene_name, gene_id)
 
-    if gene_obj is None:
-        return {"ERROR": core.config.ERROR_GENE_NOT_DEFINED_IN_DATABASE}
-    v_ann_ids["geneID_id"] = gene_obj.get_gene_id()
-    effect_obj = create_or_get_effect_obj(data["effect"], cache=cache)
-    if isinstance(effect_obj, dict):
-        return effect_obj
-    v_ann_ids["geneID_id"] = gene_obj.get_gene_id()
-    v_ann_ids["effectID_id"] = effect_obj.get_effect_id()
+    effect_id = create_or_get_effect_obj(data["effect"], cache=cache)
+    if isinstance(effect_id, dict):
+        return effect_id
+
+    v_ann_ids["geneID_id"] = gene_id
+    v_ann_ids["effectID_id"] = effect_id
     return v_ann_ids
 
 

--- a/core/api/utils/variants.py
+++ b/core/api/utils/variants.py
@@ -90,7 +90,7 @@ def create_or_get_filter_obj(filter_value, cache=None):
         cached_id = cache.get_filter(filter_value)
         if cached_id:
             return cached_id
-    filter_obj = core.models.Filter.objects.filter(filter__iexact=filter_value).last()
+    filter_obj = core.models.Filter.objects.filter(filter=filter_value).last()
     if filter_obj:
         if cache:
             cache.cache_filter(filter_value, filter_obj.pk)
@@ -112,7 +112,7 @@ def create_or_get_effect_obj(effect_value, cache=None):
         cached_id = cache.get_effect(effect_value)
         if cached_id:
             return cached_id
-    effect_obj = core.models.Effect.objects.filter(effect__iexact=effect_value).last()
+    effect_obj = core.models.Effect.objects.filter(effect=effect_value).last()
     if effect_obj:
         if cache:
             cache.cache_effect(effect_value, effect_obj.pk)
@@ -184,7 +184,7 @@ def get_variant_id(data, cache=None):
             return cached_variant_id
 
     variant_obj = core.models.Variant.objects.filter(
-        chromosomeID_id=chr_obj, pos__iexact=pos, alt__iexact=alt
+        chromosomeID_id=chr_obj, pos=pos, alt=alt
     ).last()
     if variant_obj is None:
         # Create the variant
@@ -272,9 +272,9 @@ def variant_annotation_exists(data, cache=None):
     if cache and cache.has_annotation(hgvs_c, hgvs_p, hgvs_p1):
         return True
     exists = core.models.VariantAnnotation.objects.filter(
-        hgvs_c__iexact=hgvs_c,
-        hgvs_p__iexact=hgvs_p,
-        hgvs_p_1_letter__iexact=hgvs_p1,
+        hgvs_c=hgvs_c,
+        hgvs_p=hgvs_p,
+        hgvs_p_1_letter=hgvs_p1,
     ).exists()
     if exists and cache:
         cache.cache_annotation(hgvs_c, hgvs_p, hgvs_p1)

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -705,6 +705,8 @@ def create_bioinfo_metadata(request):
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def create_variant_data(request):
+    CHUNK_SIZE = 250
+
     if request.method == "POST":
         data = request.data
         if isinstance(data, QueryDict):
@@ -797,6 +799,20 @@ def create_variant_data(request):
         variant_annotation_objects: list[core.models.VariantAnnotation] = []
         pending_annotation_keys: set[tuple[str, str, str]] = set()
 
+        def flush_chunk():
+            if variant_in_sample_objects:
+                core.models.VariantInSample.objects.bulk_create(
+                    variant_in_sample_objects, batch_size=CHUNK_SIZE
+                )
+                variant_in_sample_objects.clear()
+            if variant_annotation_objects:
+                core.models.VariantAnnotation.objects.bulk_create(
+                    variant_annotation_objects, batch_size=CHUNK_SIZE
+                )
+                variant_annotation_objects.clear()
+            pending_annotation_keys.clear()
+            cache.reset()
+
         with transaction.atomic():
             for v_data in data["variants"]:
                 split_data = core.api.utils.variants.split_variant_data(
@@ -873,14 +889,9 @@ def create_variant_data(request):
                     core.models.VariantAnnotation(**ann_kwargs)
                 )
 
-            if variant_in_sample_objects:
-                core.models.VariantInSample.objects.bulk_create(
-                    variant_in_sample_objects, batch_size=500
-                )
-            if variant_annotation_objects:
-                core.models.VariantAnnotation.objects.bulk_create(
-                    variant_annotation_objects, batch_size=500
-                )
+                if len(variant_in_sample_objects) >= CHUNK_SIZE:
+                    flush_chunk()
+            flush_chunk()
 
         sample_obj.update_state("Variant")
         # Include date and state in DateState table

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -17,6 +17,7 @@ from drf_spectacular.utils import (
 from rest_framework import serializers
 from django.http import QueryDict
 import ast
+from django.db import transaction
 
 # Local imports
 import core.urls
@@ -609,6 +610,7 @@ def create_bioinfo_metadata(request):
             description="Variant example",
             value={
                 "sample_name": "sample_name_12345",
+                "unique_sample_id": "RLCV-0000001234",
                 "variants": [
                     {
                         "Chromosome": "NC_045512.2",
@@ -660,6 +662,7 @@ def create_bioinfo_metadata(request):
         name="VariantUpload",
         fields={
             "sample_name": serializers.CharField(),
+            "unique_sample_id": serializers.CharField(required=False),
             "Variants": inline_serializer(
                 name="variant",
                 fields={
@@ -707,16 +710,58 @@ def create_variant_data(request):
         if isinstance(data, QueryDict):
             data = data.dict()
 
-        sample_obj = core.utils.samples.get_sample_obj_from_sample_name(
-            data["sample_name"]
-        )
+        sample_name = data.get("sample_name")
+        unique_sample_id = data.get("unique_sample_id")
+        sample_obj = None
+
+        # 1) Prioritise explicit unique_sample_id
+        if unique_sample_id:
+            sample_obj = core.utils.samples.get_sample_obj_from_unique_sample_id(
+                unique_sample_id
+            )
+            if sample_obj is None:
+                error = {
+                    "ERROR": core.config.ERROR_SAMPLE_NOT_DEFINED,
+                    "message": f"Sample not found for unique_sample_id '{unique_sample_id}'",
+                    "data": {},
+                }
+                return Response(error, status=status.HTTP_400_BAD_REQUEST)
+
+        # 2) Fallback to any provided sample_name
+        if sample_obj is None and sample_name:
+            sample_obj = core.utils.samples.get_sample_obj_from_sample_name(sample_name)
+            if sample_obj is None:
+                # sample_name might already contain the unique identifier
+                sample_obj = core.utils.samples.get_sample_obj_from_unique_sample_id(
+                    sample_name
+                )
+
         if sample_obj is None:
             error = {
                 "ERROR": core.config.ERROR_SAMPLE_NOT_DEFINED,
-                "message": "",
+                "message": "Sample identifier not found in platform",
                 "data": {},
             }
             return Response(error, status=status.HTTP_400_BAD_REQUEST)
+
+        # 3) If both identifiers are provided, ensure they refer to the same sample
+        if unique_sample_id and sample_name:
+            sample_unique = (getattr(sample_obj, "sample_unique_id", "") or "").strip()
+            sample_seq = (getattr(sample_obj, "sequencing_sample_id", "") or "").strip()
+            sample_name_norm = sample_name.strip().casefold()
+            sample_unique_norm = sample_unique.casefold() if sample_unique else ""
+            sample_seq_norm = sample_seq.casefold() if sample_seq else ""
+            matches_unique = sample_name_norm == sample_unique_norm
+            matches_seq = sample_name_norm == sample_seq_norm
+            if not (matches_unique or matches_seq):
+                error = {
+                    "ERROR": core.config.ERROR_SAMPLE_NOT_DEFINED,
+                    "message": (
+                        "sample_name does not match the provided unique_sample_id for the same sample"
+                    ),
+                    "data": {},
+                }
+                return Response(error, status=status.HTTP_400_BAD_REQUEST)
         analysis_defined = core.api.utils.variants.get_variant_analysis_defined(
             sample_obj
         )
@@ -747,57 +792,95 @@ def create_variant_data(request):
                 }
                 return Response(error, status=status.HTTP_400_BAD_REQUEST)
 
-        found_error = False
-        v_in_sample_list = []
-        v_an_list = []
+        cache = core.api.utils.variants.VariantProcessingCache()
+        variant_in_sample_objects: list[core.models.VariantInSample] = []
+        variant_annotation_objects: list[core.models.VariantAnnotation] = []
+        pending_annotation_keys: set[tuple[str, str, str]] = set()
 
-        for v_data in data["variants"]:
-            split_data = core.api.utils.variants.split_variant_data(
-                v_data, sample_obj, data["bioinformatics_analysis_date"]
-            )
-            if "ERROR" in split_data:
-                error = {
-                    "ERROR": split_data,
-                    "message": "error extracting variant data from request.data",
-                    "data": {},
-                }
-                found_error = True
-                break
-
-            variant_in_sample_obj = core.api.utils.variants.store_variant_in_sample(
-                split_data["variant_in_sample"]
-            )
-            if isinstance(variant_in_sample_obj, dict):
-                error = {
-                    "ERROR": variant_in_sample_obj,
-                    "message": "error storing variants for sample",
-                    "data": {},
-                }
-                found_error = True
-                break
-
-            v_in_sample_list.append(variant_in_sample_obj)
-
-            if not core.api.utils.variants.variant_annotation_exists(
-                split_data["variant_ann"]
-            ):
-                variant_ann_obj = core.api.utils.variants.store_variant_annotation(
-                    split_data["variant_ann"]
+        with transaction.atomic():
+            for v_data in data["variants"]:
+                split_data = core.api.utils.variants.split_variant_data(
+                    v_data,
+                    sample_obj,
+                    data["bioinformatics_analysis_date"],
+                    cache=cache,
                 )
-                if isinstance(variant_ann_obj, dict):
-                    error = {
-                        "ERROR": variant_ann_obj,
-                        "message": "error storing variant annotations",
-                        "data": {},
-                    }
-                    found_error = True
-                    break
+                if "ERROR" in split_data:
+                    return Response(
+                        {
+                            "ERROR": split_data,
+                            "message": "error extracting variant data from request.data",
+                            "data": {},
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
 
-                v_an_list.append(variant_ann_obj)
+                variant_in_sample_data = split_data["variant_in_sample"]
+                try:
+                    variant_id = int(variant_in_sample_data["variantID_id"])
+                except (ValueError, TypeError) as exc:
+                    return Response(
+                        {
+                            "ERROR": f"Invalid variantID_id value: {variant_in_sample_data.get('variantID_id')}",
+                            "message": str(exc),
+                            "data": {},
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
 
-        if found_error:
-            core.api.utils.variants.delete_created_variancs(v_in_sample_list, v_an_list)
-            return Response(error, status=status.HTTP_400_BAD_REQUEST)
+                variant_kwargs = {
+                    key: value
+                    for key, value in variant_in_sample_data.items()
+                    if key != "variantID_id"
+                }
+                variant_kwargs["sampleID_id"] = sample_obj
+                variant_kwargs["variantID_id_id"] = variant_id
+
+                variant_in_sample_objects.append(
+                    core.models.VariantInSample(**variant_kwargs)
+                )
+
+                ann_data = split_data["variant_ann"].copy()
+                ann_key = (
+                    cache._norm(ann_data.get("hgvs_c")),
+                    cache._norm(ann_data.get("hgvs_p")),
+                    cache._norm(ann_data.get("hgvs_p_1_letter")),
+                )
+
+                if ann_key in pending_annotation_keys:
+                    continue
+
+                if core.api.utils.variants.variant_annotation_exists(
+                    ann_data, cache=cache
+                ):
+                    continue
+
+                cache.cache_annotation(
+                    ann_data.get("hgvs_c"),
+                    ann_data.get("hgvs_p"),
+                    ann_data.get("hgvs_p_1_letter"),
+                )
+                pending_annotation_keys.add(ann_key)
+                ann_kwargs = {
+                    key: value
+                    for key, value in ann_data.items()
+                    if key not in {"variantID_id", "geneID_id", "effectID_id"}
+                }
+                ann_kwargs["variantID_id_id"] = variant_id
+                ann_kwargs["geneID_id_id"] = ann_data.get("geneID_id")
+                ann_kwargs["effectID_id_id"] = ann_data.get("effectID_id")
+                variant_annotation_objects.append(
+                    core.models.VariantAnnotation(**ann_kwargs)
+                )
+
+            if variant_in_sample_objects:
+                core.models.VariantInSample.objects.bulk_create(
+                    variant_in_sample_objects, batch_size=500
+                )
+            if variant_annotation_objects:
+                core.models.VariantAnnotation.objects.bulk_create(
+                    variant_annotation_objects, batch_size=500
+                )
 
         sample_obj.update_state("Variant")
         # Include date and state in DateState table

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -800,98 +800,99 @@ def create_variant_data(request):
         pending_annotation_keys: set[tuple[str, str, str]] = set()
 
         def flush_chunk():
-            if variant_in_sample_objects:
-                core.models.VariantInSample.objects.bulk_create(
-                    variant_in_sample_objects, batch_size=CHUNK_SIZE
-                )
-                variant_in_sample_objects.clear()
-            if variant_annotation_objects:
-                core.models.VariantAnnotation.objects.bulk_create(
-                    variant_annotation_objects, batch_size=CHUNK_SIZE
-                )
-                variant_annotation_objects.clear()
+            if not variant_in_sample_objects and not variant_annotation_objects:
+                return
+            with transaction.atomic():
+                if variant_in_sample_objects:
+                    core.models.VariantInSample.objects.bulk_create(
+                        variant_in_sample_objects, batch_size=CHUNK_SIZE
+                    )
+                    variant_in_sample_objects.clear()
+                if variant_annotation_objects:
+                    core.models.VariantAnnotation.objects.bulk_create(
+                        variant_annotation_objects, batch_size=CHUNK_SIZE
+                    )
+                    variant_annotation_objects.clear()
+
             pending_annotation_keys.clear()
             cache.reset()
 
-        with transaction.atomic():
-            for v_data in data["variants"]:
-                split_data = core.api.utils.variants.split_variant_data(
-                    v_data,
-                    sample_obj,
-                    data["bioinformatics_analysis_date"],
-                    cache=cache,
-                )
-                if "ERROR" in split_data:
-                    return Response(
-                        {
-                            "ERROR": split_data,
-                            "message": "error extracting variant data from request.data",
-                            "data": {},
-                        },
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
-
-                variant_in_sample_data = split_data["variant_in_sample"]
-                try:
-                    variant_id = int(variant_in_sample_data["variantID_id"])
-                except (ValueError, TypeError) as exc:
-                    return Response(
-                        {
-                            "ERROR": f"Invalid variantID_id value: {variant_in_sample_data.get('variantID_id')}",
-                            "message": str(exc),
-                            "data": {},
-                        },
-                        status=status.HTTP_400_BAD_REQUEST,
-                    )
-
-                variant_kwargs = {
-                    key: value
-                    for key, value in variant_in_sample_data.items()
-                    if key != "variantID_id"
-                }
-                variant_kwargs["sampleID_id"] = sample_obj
-                variant_kwargs["variantID_id_id"] = variant_id
-
-                variant_in_sample_objects.append(
-                    core.models.VariantInSample(**variant_kwargs)
+        for v_data in data["variants"]:
+            split_data = core.api.utils.variants.split_variant_data(
+                v_data,
+                sample_obj,
+                data["bioinformatics_analysis_date"],
+                cache=cache,
+            )
+            if "ERROR" in split_data:
+                return Response(
+                    {
+                        "ERROR": split_data,
+                        "message": "error extracting variant data from request.data",
+                        "data": {},
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
 
-                ann_data = split_data["variant_ann"].copy()
-                ann_key = (
-                    cache._norm(ann_data.get("hgvs_c")),
-                    cache._norm(ann_data.get("hgvs_p")),
-                    cache._norm(ann_data.get("hgvs_p_1_letter")),
+            variant_in_sample_data = split_data["variant_in_sample"]
+            try:
+                variant_id = int(variant_in_sample_data["variantID_id"])
+            except (ValueError, TypeError) as exc:
+                return Response(
+                    {
+                        "ERROR": f"Invalid variantID_id value: {variant_in_sample_data.get('variantID_id')}",
+                        "message": str(exc),
+                        "data": {},
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
 
-                if ann_key in pending_annotation_keys:
-                    continue
+            variant_kwargs = {
+                key: value
+                for key, value in variant_in_sample_data.items()
+                if key != "variantID_id"
+            }
+            variant_kwargs["sampleID_id"] = sample_obj
+            variant_kwargs["variantID_id_id"] = variant_id
 
-                if core.api.utils.variants.variant_annotation_exists(
-                    ann_data, cache=cache
-                ):
-                    continue
+            variant_in_sample_objects.append(
+                core.models.VariantInSample(**variant_kwargs)
+            )
 
-                cache.cache_annotation(
-                    ann_data.get("hgvs_c"),
-                    ann_data.get("hgvs_p"),
-                    ann_data.get("hgvs_p_1_letter"),
-                )
-                pending_annotation_keys.add(ann_key)
-                ann_kwargs = {
-                    key: value
-                    for key, value in ann_data.items()
-                    if key not in {"variantID_id", "geneID_id", "effectID_id"}
-                }
-                ann_kwargs["variantID_id_id"] = variant_id
-                ann_kwargs["geneID_id_id"] = ann_data.get("geneID_id")
-                ann_kwargs["effectID_id_id"] = ann_data.get("effectID_id")
-                variant_annotation_objects.append(
-                    core.models.VariantAnnotation(**ann_kwargs)
-                )
+            ann_data = split_data["variant_ann"].copy()
+            ann_key = (
+                cache._norm(ann_data.get("hgvs_c")),
+                cache._norm(ann_data.get("hgvs_p")),
+                cache._norm(ann_data.get("hgvs_p_1_letter")),
+            )
 
-                if len(variant_in_sample_objects) >= CHUNK_SIZE:
-                    flush_chunk()
-            flush_chunk()
+            if ann_key in pending_annotation_keys:
+                continue
+
+            if core.api.utils.variants.variant_annotation_exists(ann_data, cache=cache):
+                continue
+
+            cache.cache_annotation(
+                ann_data.get("hgvs_c"),
+                ann_data.get("hgvs_p"),
+                ann_data.get("hgvs_p_1_letter"),
+            )
+            pending_annotation_keys.add(ann_key)
+            ann_kwargs = {
+                key: value
+                for key, value in ann_data.items()
+                if key not in {"variantID_id", "geneID_id", "effectID_id"}
+            }
+            ann_kwargs["variantID_id_id"] = variant_id
+            ann_kwargs["geneID_id_id"] = ann_data.get("geneID_id")
+            ann_kwargs["effectID_id_id"] = ann_data.get("effectID_id")
+            variant_annotation_objects.append(
+                core.models.VariantAnnotation(**ann_kwargs)
+            )
+
+            if len(variant_in_sample_objects) >= CHUNK_SIZE:
+                flush_chunk()
+        flush_chunk()
 
         sample_obj.update_state("Variant")
         # Include date and state in DateState table

--- a/core/models.py
+++ b/core/models.py
@@ -990,6 +990,12 @@ class Variant(models.Model):
 
     class Meta:
         db_table = "core_variant"
+        indexes = [
+            models.Index(
+                fields=["chromosomeID_id", "pos", "alt"],
+                name="variant_chr_pos_alt_idx",
+            ),
+        ]
 
     def __str__(self):
         return "%s_%s" % (self.pos, self.alt)
@@ -1031,6 +1037,16 @@ class VariantInSample(models.Model):
 
     class Meta:
         db_table = "core_variant_in_sample"
+        indexes = [
+            models.Index(
+                fields=["sampleID_id", "bioinformatics_analysis_date"],
+                name="vinsample_sampdate_idx",
+            ),
+            models.Index(
+                fields=["variantID_id"],
+                name="variantinsample_variant_idx",
+            ),
+        ]
 
     def __str__(self):
         return "%s_%s" % (self.sampleID_id, self.variantID_id)
@@ -1107,6 +1123,12 @@ class VariantAnnotation(models.Model):
 
     class Meta:
         db_table = "core_variant_annotation"
+        indexes = [
+            models.Index(
+                fields=["hgvs_c", "hgvs_p", "hgvs_p_1_letter"],
+                name="variant_annotation_hgvs_idx",
+            ),
+        ]
 
     def __str__(self):
         return "%s" % (self.variantID_id)

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -117,6 +117,7 @@ def get_bioinfo_analyis_fields_utilization(
     through_model = core.models.Sample.bio_analysis_values.through
     batch_size = 500
     fields_counter = Counter()
+    touched_labels = set()
 
     sample_iter = (
         core.models.Sample.objects.filter(**sample_filter)
@@ -131,16 +132,26 @@ def get_bioinfo_analyis_fields_utilization(
         seen_pairs = set()
         rows = (
             through_model.objects.filter(sample_id__in=batch)
-            .filter(bioinfoanalysisvalue__value__isnull=False)
-            .exclude(bioinfoanalysisvalue__value__in=FIELD_EMPTY)
             .values_list(
                 "bioinfoanalysisvalue__bioinfo_analysis_fieldID__label_name",
                 "sample_id",
+                "bioinfoanalysisvalue__value",
             )
             .iterator(chunk_size=batch_size)
         )
 
-        for label, sample_id in rows:
+        for label, sample_id, raw_value in rows:
+            if label is None:
+                continue
+            touched_labels.add(label)
+
+            if raw_value is None:
+                continue
+
+            value = raw_value.strip() if isinstance(raw_value, str) else raw_value
+            if value in FIELD_EMPTY:
+                continue
+
             key = (label, sample_id)
             if key in seen_pairs:
                 continue
@@ -157,13 +168,17 @@ def get_bioinfo_analyis_fields_utilization(
         .values_list("label_name", flat=True)
         .distinct()
     )
-    never_used = defined_labels - labels_with_value
+    never_used = defined_labels - touched_labels
+    always_none = touched_labels - labels_with_value
+
+    for label in always_none | never_used:
+        fields_value.setdefault(label, 0)
 
     result = {
         "fields_value": fields_value,
         "fields_norm": fields_norm,
         "never_used": list(never_used),
-        "always_none": list(never_used),  # backward-compat
+        "always_none": list(always_none),
         "num_samples": num_samples,
     }
 

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -329,11 +329,19 @@ def create_dash_bar_for_each_lab(labs_data, labs_list=None):
 
     legacy_column = df_data.get("legacy_collecting_institution")
     if "collecting_institution" in df_data.columns:
-        df_data["collecting_institution"] = df_data["collecting_institution"].fillna(
-            legacy_column
-        )
+        if legacy_column is not None:
+            df_data["collecting_institution"] = df_data[
+                "collecting_institution"
+            ].fillna(legacy_column)
+        else:
+            df_data["collecting_institution"] = df_data[
+                "collecting_institution"
+            ].fillna("")
     else:
-        df_data["collecting_institution"] = legacy_column
+        if legacy_column is not None:
+            df_data["collecting_institution"] = legacy_column.fillna("")
+        else:
+            df_data["collecting_institution"] = ""
 
     if labs_list is None:
         labs_list = []


### PR DESCRIPTION
## PR Description

### 1. Long-table upload keyed by unique_sample_id

All long-table ingestion paths now resolve and persist rows using `unique_sample_id` as the canonical key.
Faster variantdata upload to the platform:

- Added `per-request caches` in core/api/utils/variants.py to reuse filters, effects, genes, variants, and annotations across a payload.
- Wrapped create_variant_data in a single transaction and switched to `bulk_create` for both VariantInSample and VariantAnnotation.
- Created `composite indexes` on Variant, VariantInSample, and VariantAnnotation to speed up `repeated lookups`.

### 2. fix Bioinfo field stats so never_used and always_none are reported separately.