### PR TITLE
Stabilize django-plotly-dash apps by registering them at startup

### DIFF
--- a/conf/template_settings.py
+++ b/conf/template_settings.py
@@ -147,7 +147,10 @@ PLOTLY_COMPONENTS = [
 
 PLOTLY_DASH = {
     "view_decorator": "django_plotly_dash.access.login_required",
-    "cache_arguments": True,
+    # Use the Django session backend for initial_arguments. The default cache is
+    # LocMemCache in this deployment, which is process-local and breaks Dash
+    # iframe initial state across multiple workers.
+    "cache_arguments": False,
     "serve_locally": True,
 }
 

--- a/conf/template_settings.py
+++ b/conf/template_settings.py
@@ -45,6 +45,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_plotly_dash.middleware.BaseMiddleware",
+    "django_plotly_dash.middleware.ExternalRedirectionMiddleware",
 ]
 
 ROOT_URLCONF = "relecov_platform.urls"
@@ -132,16 +133,23 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
     "django_plotly_dash.finders.DashAssetFinder",
+    "django_plotly_dash.finders.DashAppDirectoryFinder",
     "core.finders.DashComponentFinderNoDuplicates",
 ]
 
 PLOTLY_COMPONENTS = [
-    "dash.dcc",
-    "dash.html",
     "dpd_components",
-    # Other components, as needed
-    # "dash_bootstrap_components",
+    "dpd_static_support",
+    "dash_bootstrap_components",
+    "dash_daq",
+    "dash_bio",
 ]
+
+PLOTLY_DASH = {
+    "view_decorator": "django_plotly_dash.access.login_required",
+    "cache_arguments": True,
+    "serve_locally": True,
+}
 
 SWAGGER_SETTINGS = {"SECURITY_DEFINITIONS": {"basic": {"type": "basic"}}}
 

--- a/core/apps.py
+++ b/core/apps.py
@@ -5,3 +5,8 @@ from django.apps import AppConfig
 class RelecovCoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"
+
+    def ready(self):
+        from core.dash_apps import register_all
+
+        register_all()

--- a/core/dash_apps/__init__.py
+++ b/core/dash_apps/__init__.py
@@ -1,0 +1,15 @@
+from .sample_per_lab import register as register_sample_per_lab
+from .sample_variant import register as register_sample_variant
+from .samples_received_map import register as register_samples_received_map
+
+_REGISTERED = False
+
+
+def register_all():
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    register_sample_per_lab()
+    register_sample_variant()
+    register_samples_received_map()
+    _REGISTERED = True

--- a/core/dash_apps/sample_per_lab.py
+++ b/core/dash_apps/sample_per_lab.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 import core.utils.plotly_dash_graphics
 
-
 APP_NAME = "samplePerLabGraphic"
 
 

--- a/core/dash_apps/sample_per_lab.py
+++ b/core/dash_apps/sample_per_lab.py
@@ -1,0 +1,114 @@
+from dash import dcc, html
+from dash.dependencies import Input, Output, State
+from dash.exceptions import PreventUpdate
+from django_plotly_dash import DjangoDash
+import plotly.express as px
+import plotly.graph_objects as go
+import pandas as pd
+
+import core.utils.plotly_dash_graphics
+
+
+APP_NAME = "samplePerLabGraphic"
+
+
+def _empty_figure():
+    fig = go.Figure()
+    fig.update_layout(
+        title="No data available for the selected laboratory",
+        template=core.utils.plotly_dash_graphics.mi_template,
+        xaxis_title="Collecting date (ISOWeeks)",
+        yaxis_title="Number of samples",
+        margin=dict(l=20, r=40, t=30, b=20),
+    )
+    return fig
+
+
+def register():
+    app = DjangoDash(
+        APP_NAME,
+        external_stylesheets=[
+            "https://fonts.googleapis.com/css2?family=Oxanium&display=swap",
+            "/static/core/css/dash_style.css",
+        ],
+    )
+
+    app.layout = html.Div(
+        [
+            html.H4("Select the laboratory", style={"fontFamily": "Oxanium"}),
+            dcc.Dropdown(
+                id="select_collecting_inst",
+                options=[],
+                clearable=False,
+                multi=False,
+                value=None,
+                style={"width": "400px"},
+            ),
+            dcc.Store(id="sample_per_lab_data", data=[]),
+            html.Br(),
+            dcc.Graph(id="bar_graph", figure=_empty_figure()),
+        ]
+    )
+
+    @app.callback(
+        Output("bar_graph", "figure"),
+        Input("select_collecting_inst", "value"),
+        State("sample_per_lab_data", "data"),
+    )
+    def update_graph(select_collecting_inst, data):
+        if not select_collecting_inst:
+            raise PreventUpdate
+        df = pd.DataFrame(data or [])
+        if df.empty:
+            return _empty_figure()
+
+        selected = str(select_collecting_inst)
+        if "lab_code_1" in df.columns:
+            mask = df["lab_code_1"].fillna("").astype(str) == selected
+            fallback_mask = pd.Series(False, index=df.index)
+            for column in [
+                col
+                for col in ["collecting_institution", "legacy_collecting_institution"]
+                if col in df.columns
+            ]:
+                fallback_mask = fallback_mask | (
+                    df[column].fillna("").astype(str) == selected
+                )
+            df = df[mask | fallback_mask]
+        elif "collecting_institution" in df.columns:
+            df = df[df["collecting_institution"].fillna("").astype(str) == selected]
+        else:
+            df = df.iloc[0:0]
+
+        if df.empty:
+            return _empty_figure()
+
+        sub_data = df.drop_duplicates(subset=["iso_yearweek"]).reset_index(drop=True)
+        sub_data["iso_yearweek"] = sub_data["iso_yearweek"].astype(str).str.replace(
+            r"W(\d{1})$", r"W0\1", regex=True
+        )
+        sub_data["num_samples"] = pd.to_numeric(
+            sub_data["num_samples"], errors="coerce"
+        ).fillna(0).astype(int)
+        sub_data = sub_data.sort_values("iso_yearweek")
+
+        graph = px.bar(
+            sub_data,
+            x=sub_data["iso_yearweek"].astype(str),
+            y=sub_data["num_samples"].astype(int),
+            text_auto=True,
+        )
+        graph.update_traces(
+            marker=dict(color=core.utils.plotly_dash_graphics.COLOR_PALETTE[1]),
+            opacity=0.6,
+        )
+        graph.update_layout(
+            title="Registered samples over time",
+            autotypenumbers="convert types",
+            template=core.utils.plotly_dash_graphics.mi_template,
+            xaxis_tickangle=-45,
+            margin=dict(l=20, r=40, t=30, b=20),
+            xaxis_title="Collecting date (ISOWeeks)",
+            yaxis_title="Number of samples",
+        )
+        return graph

--- a/core/dash_apps/sample_per_lab.py
+++ b/core/dash_apps/sample_per_lab.py
@@ -84,12 +84,16 @@ def register():
             return _empty_figure()
 
         sub_data = df.drop_duplicates(subset=["iso_yearweek"]).reset_index(drop=True)
-        sub_data["iso_yearweek"] = sub_data["iso_yearweek"].astype(str).str.replace(
-            r"W(\d{1})$", r"W0\1", regex=True
+        sub_data["iso_yearweek"] = (
+            sub_data["iso_yearweek"]
+            .astype(str)
+            .str.replace(r"W(\d{1})$", r"W0\1", regex=True)
         )
-        sub_data["num_samples"] = pd.to_numeric(
-            sub_data["num_samples"], errors="coerce"
-        ).fillna(0).astype(int)
+        sub_data["num_samples"] = (
+            pd.to_numeric(sub_data["num_samples"], errors="coerce")
+            .fillna(0)
+            .astype(int)
+        )
         sub_data = sub_data.sort_values("iso_yearweek")
 
         graph = px.bar(

--- a/core/dash_apps/sample_variant.py
+++ b/core/dash_apps/sample_variant.py
@@ -5,7 +5,6 @@ from django_plotly_dash import DjangoDash
 
 import core.utils.plotly_graphics
 
-
 APP_NAME = "sampleVariantGraphic"
 
 

--- a/core/dash_apps/sample_variant.py
+++ b/core/dash_apps/sample_variant.py
@@ -116,4 +116,3 @@ def register():
             "prev_relayout": relayout_data,
         }
         return figure, "Showing mutations for selected sample", next_data
-

--- a/core/dash_apps/sample_variant.py
+++ b/core/dash_apps/sample_variant.py
@@ -1,0 +1,119 @@
+from dash import dcc, html
+from dash.dependencies import Input, Output, State
+from dash.exceptions import PreventUpdate
+from django_plotly_dash import DjangoDash
+
+import core.utils.plotly_graphics
+
+
+APP_NAME = "sampleVariantGraphic"
+
+
+def register():
+    app = DjangoDash(
+        APP_NAME,
+        external_stylesheets=[
+            "https://fonts.googleapis.com/css2?family=Oxanium&display=swap",
+            "/static/core/css/dash_style.css",
+        ],
+    )
+
+    app.layout = html.Div(
+        children=[
+            html.Div(
+                children=[
+                    html.Div(
+                        [
+                            "Show Range Slider",
+                            dcc.Checklist(
+                                id="toggle-rangeslider",
+                                options=[{"label": "Enable", "value": "on"}],
+                                value=["on"],
+                                inline=True,
+                            ),
+                        ],
+                        style={"margin-left": "20px"},
+                    ),
+                    html.Div(
+                        children=[dcc.Markdown(id="samples_markdown")],
+                        style={"margin-left": "50px"},
+                    ),
+                ],
+                style={
+                    "display": "flex",
+                    "justify-content": "start",
+                    "align-items": "flex-start",
+                },
+            ),
+            html.Div(
+                children=[
+                    dcc.Loading(
+                        id="loading_plot_wrapper",
+                        type="default",
+                        children=[
+                            html.Div(
+                                id="needleplot-container-div",
+                                children=[
+                                    dcc.Store(id="mdata-store", data={}),
+                                    dcc.Graph(
+                                        id="needleplot-graph",
+                                        style={"padding-top": "15px"},
+                                        figure=core.utils.plotly_graphics.empty_sample_variant_figure(),
+                                    ),
+                                ],
+                                style={"position": "relative"},
+                            )
+                        ],
+                        overlay_style={"visibility": "visible", "filter": "blur(1px)"},
+                        parent_style={"position": "relative"},
+                    ),
+                    dcc.Store(
+                        id="previous-data",
+                        storage_type="memory",
+                        data={"first_load": True},
+                    ),
+                ],
+            ),
+        ]
+    )
+
+    @app.callback(
+        [
+            Output("needleplot-graph", "figure"),
+            Output("samples_markdown", "children"),
+            Output("previous-data", "data"),
+        ],
+        [
+            Input("mdata-store", "data"),
+            Input("toggle-rangeslider", "value"),
+            Input("needleplot-graph", "relayoutData"),
+        ],
+        State("previous-data", "data"),
+    )
+    def update_sample(mdata, toggle_rangeslider, relayout_data, prev_data):
+        if not mdata or not mdata.get("x"):
+            return (
+                core.utils.plotly_graphics.empty_sample_variant_figure(),
+                "No variants available for the selected sample",
+                {"first_load": False},
+            )
+
+        previous_data = prev_data or {"first_load": True}
+        if (
+            not previous_data.get("first_load", True)
+            and relayout_data
+            and previous_data.get("prev_relayout") == relayout_data
+        ):
+            raise PreventUpdate
+
+        figure = core.utils.plotly_graphics.build_sample_variant_figure(
+            mdata,
+            toggle_rangeslider=toggle_rangeslider,
+            relayout_data=relayout_data,
+        )
+        next_data = {
+            "first_load": False,
+            "prev_relayout": relayout_data,
+        }
+        return figure, "Showing mutations for selected sample", next_data
+

--- a/core/dash_apps/samples_received_map.py
+++ b/core/dash_apps/samples_received_map.py
@@ -4,7 +4,6 @@ from django_plotly_dash import DjangoDash
 
 import core.utils.samples_map
 
-
 APP_NAME = "samplesReceivedOverTimeMap"
 
 

--- a/core/dash_apps/samples_received_map.py
+++ b/core/dash_apps/samples_received_map.py
@@ -1,0 +1,33 @@
+from dash import dcc, html
+from dash.dependencies import Input, Output
+from django_plotly_dash import DjangoDash
+
+import core.utils.samples_map
+
+
+APP_NAME = "samplesReceivedOverTimeMap"
+
+
+def register():
+    app = DjangoDash(APP_NAME)
+
+    app.layout = html.Div(
+        children=[
+            dcc.Interval(id="samples-received-map-load", interval=1, n_intervals=0, max_intervals=1),
+            html.Iframe(
+                id="samples-received-map-frame",
+                srcDoc="",
+                style={"width": "100%", "height": "800px", "border": "0"},
+            ),
+        ],
+    )
+
+    @app.callback(
+        Output("samples-received-map-frame", "srcDoc"),
+        Input("samples-received-map-load", "n_intervals"),
+    )
+    def load_map(_n_intervals):
+        result = core.utils.samples_map.build_samples_received_map_html()
+        if isinstance(result, dict) and "ERROR" in result:
+            return "<h3>Unable to load received samples map</h3>"
+        return result

--- a/core/dash_apps/samples_received_map.py
+++ b/core/dash_apps/samples_received_map.py
@@ -13,7 +13,12 @@ def register():
 
     app.layout = html.Div(
         children=[
-            dcc.Interval(id="samples-received-map-load", interval=1, n_intervals=0, max_intervals=1),
+            dcc.Interval(
+                id="samples-received-map-load",
+                interval=1,
+                n_intervals=0,
+                max_intervals=1,
+            ),
             html.Iframe(
                 id="samples-received-map-frame",
                 srcDoc="",

--- a/core/templates/core/intranet.html
+++ b/core/templates/core/intranet.html
@@ -70,7 +70,7 @@
                                                                             {{ manager_intra_data.sample_gauge_graph | safe }}
                                                                     </div> <!-- end col-md-5 -->
                                                                     <div class="col-md-12">
-                                                                        {% plotly_app name="samplePerLabGraphic" ratio=1 %}
+                                                                        {% plotly_app name="samplePerLabGraphic" ratio=1 initial_arguments=manager_intra_data.sample_per_lab_initial_arguments %}
                                                                 </div> <!-- end col-md-7 -->
                                                                 {% else %}
                                                                     <div class="col-md-7">
@@ -294,7 +294,7 @@
                                                             {% if intra_data.show_per_lab_dash %}
                                                             <div class="col-md-12">
                                                                 <div style="max-width: 100%; overflow-x: auto;">
-                                                                    {% plotly_app name="samplePerLabGraphic" ratio=1 %}
+                                                                        {% plotly_app name="samplePerLabGraphic" ratio=1 initial_arguments=intra_data.sample_per_lab_initial_arguments %}
                                                                 </div>
                                                             </div> <!-- end col-md-7 -->
                                                             {% endif %}

--- a/core/templates/core/sampleDisplay.html
+++ b/core/templates/core/sampleDisplay.html
@@ -470,7 +470,7 @@
                                             <div class="tab-pane fade active" id="graphic" role="tabpanel" aria-labelledby="graphic-tab">
                                                 <div class="col-md-12">
 
-                                                    {% plotly_app name="sampleVariantGraphic" ratio=1.0 %}
+                                                    {% plotly_app name="sampleVariantGraphic" ratio=1.0 initial_arguments=sample_data.graphic %}
                                                 </div> <!-- end col-md-12 -->
                                             </div>
                                         {% endif %}

--- a/core/utils/plotly_graphics.py
+++ b/core/utils/plotly_graphics.py
@@ -1,13 +1,8 @@
 # Generic imports
-import time
 from plotly.offline import plot
 import plotly.graph_objects as go
 import plotly.express as px
 import plotly.figure_factory as ff
-import dash
-from dash import dcc, html
-from django_plotly_dash import DjangoDash
-from dash.dependencies import Input, Output
 from django.template.loader import render_to_string
 
 COLOR_PALETTE = [
@@ -223,343 +218,222 @@ def pie_graphic(data, names, title, show_legend=False):
     return plot_div
 
 
-def needle_plot(mdata):
-    """Create a needleplot using dash that represents mutations along some
-    genomic regions.
-    """
-    mdata = mdata.copy()
-    mdata["x"] = [int(x) for x in mdata["x"]]
-    app = DjangoDash("sampleVariantGraphic", serve_locally=True)
-    app.layout = html.Div(
-        children=[
-            html.Div(
-                children=[
-                    html.Div(
-                        [
-                            "Show Range Slider",
-                            dcc.Checklist(
-                                id="toggle-rangeslider",
-                                options=[{"label": "Enable", "value": "on"}],
-                                value=["on"],
-                                inline=True,
-                            ),
-                        ],
-                        style={"margin-left": "20px"},
-                    ),
-                    html.Div(
-                        children=[
-                            dcc.Markdown(
-                                id="samples_markdown",
-                            )
-                        ],
-                        style={"margin-left": "50px"},
-                    ),
-                ],
-                style={
-                    "display": "flex",
-                    "justify-content": "start",
-                    "align-items": "flex-start",
-                },
-            ),
-            html.Div(
-                children=[
-                    dcc.Loading(
-                        id="loading_plot_wrapper",
-                        type="default",
-                        children=[
-                            html.Div(
-                                id="needleplot-container-div",
-                                children=[
-                                    dcc.Store(id="mdata-store", data=mdata),
-                                    dcc.Graph(
-                                        id="needleplot-graph",
-                                        style={"padding-top": "15px"},
-                                    ),
-                                ],
-                                style={"position": "relative"},
-                            )
-                        ],
-                        overlay_style={"visibility": "visible", "filter": "blur(1px)"},
-                        parent_style={"position": "relative"},
-                    ),
-                    dcc.Store(
-                        id="previous-data",
-                        storage_type="memory",
-                        data={"first_load": True},
-                    ),
-                ],
-            ),
-        ]
+def empty_sample_variant_figure():
+    fig = go.Figure()
+    fig.update_layout(
+        title="No variants available for the selected sample",
+        template=mi_template,
+        xaxis_title="Genome Position",
+        yaxis_title="Allele Frequency",
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        yaxis_range=[-0.12, 1.15],
     )
+    return fig
 
-    @app.callback(
-        [
-            Output("needleplot-graph", "figure"),
-            Output("samples_markdown", "children"),
-            Output("previous-data", "data"),
-        ],  # Track loading state
-        [
-            Input("mdata-store", "data"),
-            Input("toggle-rangeslider", "value"),
-            Input("needleplot-graph", "relayoutData"),
-            Input("previous-data", "data"),
-        ],
-        prevent_initial_call=True,  # Avoid triggering on page load
-    )
-    def update_sample(mdata, toogle_rangeslider, relayout_data, prev_data):
-        current_time = time.time()
-        first_load = prev_data["first_load"]
-        next_data = {}
-        if not relayout_data:
-            next_data["prev_relayout"] = relayout_data
-        if not first_load:
-            last_time = prev_data["last_update"]
-            # Dont update if no relayout_data is returned from rangeslider
-            if not relayout_data or not relayout_data.get("xaxis.range", []):
-                print("No valid relayout data found")
-                raise dash.exceptions.PreventUpdate
-            # Compare current relayoutData with the previous one
-            previous_range = prev_data.get("xaxis.range", [])
-            current_range = relayout_data.get("xaxis.range", [])
-            if previous_range == current_range:
-                print("No change in relayoutData, skipping update.")
-                raise dash.exceptions.PreventUpdate
-            last_time = prev_data["last_update"]
-            # Ensure that the last state has not been updated too recently
-            if current_time - last_time < 0.25:
-                print(f"Did not update. Diff was {time.time() - last_time}")
-                raise dash.exceptions.PreventUpdate
-        # Update previous relayout data
-        next_data["prev_relayout"] = relayout_data
-        next_data["first_load"] = False
-        # Start updating process
-        next_data["last_update"] = current_time
-        markdown_text = "Showing mutations for selected sample"
-        # TODO: Include all color mapping dicts for domains and mutation types in graphic_json
-        domain_color_map = {
-            "orf1ab": "#1f77b4",  # Blue
-            "S": "#ff7f0e",  # Orange
-            "ORF3a": "#2ca02c",  # Green
-            "E": "#d62728",  # Red
-            "M": "#9467bd",  # Purple
-            "ORF6": "#8c564b",  # Brown
-            "ORF7a": "#e377c2",  # Pink
-            "ORF7b": "#7f7f7f",  # Gray
-            "ORF8": "#bcbd22",  # Yellow-green
-            "N": "#17becf",  # Cyan
-            "ORF10": "#ffbb78",  # Light orange
-        }
-        mutation_color_map = {
-            "missense_variant": "#E6194B",  # Red
-            "Unknown": "#A9A9A9",  # Gray THESE ARE RENAMED FROM NONE VALUES
-            "disruptive_inframe_insertion": "#BFEF45",  # Light Green
-            "frameshift_variant": "#F58231",  # Orange
-            "splice_region_variant&stop_retained_variant": "#FF8DA1",  # Pink
-            "conservative_inframe_deletion": "#BF8970",  # Yellow
-            "synonymous_variant": "#4363D8",  # Blue
-            "stop_lost": "#42D4F4",  # Cyan
-            "frameshift_variant&start_lost": "#F032E6",  # Magenta
-            "start_lost": "#3CB44B",  # Green
-            "disruptive_inframe_deletion": "#D4AF37",  # Light Red
-            "gene_fusion": "#469990",  # Teal
-            "conservative_inframe_insertion": "#DCBEFF",  # Lavender
-            "stop_gained": "#9A6324",  # Brown
-            "upstream_gene_variant": "#911EB4",  # Purple
-            "frameshift_variant&stop_lost&splice_region_variant": "#800000",  # Dark Red
-            "frameshift_variant&stop_gained": "#A65628",  # Dark Brown
-            "stop_retained_variant": "#FF6347",  # Tomato Red
-            "downstream_gene_variant": "#808000",  # Olive
-        }
 
-        # Create NeedlePlot and extract figure
-        fig = go.Figure()
-        if toogle_rangeslider == ["on"]:
-            fig.update_layout(
-                xaxis_rangeslider=dict(visible=True, bgcolor="rgba(255, 255, 255, 0)")
-            )
-        if relayout_data and "xaxis.range" in relayout_data:
-            # relayout data listens to updates in the plot from rangeslider
-            min_x, max_x = relayout_data["xaxis.range"]
-            fig.update_layout(xaxis=dict(range=relayout_data["xaxis.range"]))
-        else:
-            min_x, max_x = (min(mdata["x"]), max(mdata["x"]))
+def build_sample_variant_initial_arguments(mdata):
+    normalized = {
+        "x": [int(x) for x in mdata.get("x", []) if x is not None],
+        "y": list(mdata.get("y", [])),
+        "mutationGroups": list(mdata.get("mutationGroups", [])),
+        "domains": list(mdata.get("domains", [])),
+    }
+    return {
+        "mdata-store": {"data": normalized},
+        "toggle-rangeslider": {"value": ["on"]},
+        "previous-data": {"data": {"first_load": True}},
+    }
 
-        # X range will be used to define wether to show genome annotations
-        x_range = max_x - min_x
 
-        max_pos = 0
-        # Store used annotation possitions to avoid overlap
-        used_annotations = []
-        all_max_x = max([int(x["coord"].split("-")[1]) for x in mdata["domains"]])
-        domain_selectors = [
-            dict(
-                label="All",
-                method="relayout",
-                args=[{"xaxis.range": [0, all_max_x]}],
-            )
-        ]
-        # Sort domains based on their starting positions, needed for annotations
-        sorted_domains = sorted(
-            mdata["domains"], key=lambda x: int(x["coord"].split("-")[0])
+def build_sample_variant_figure(mdata, toggle_rangeslider=None, relayout_data=None):
+    if not mdata or not mdata.get("x"):
+        return empty_sample_variant_figure()
+
+    domain_color_map = {
+        "orf1ab": "#1f77b4",
+        "S": "#ff7f0e",
+        "ORF3a": "#2ca02c",
+        "E": "#d62728",
+        "M": "#9467bd",
+        "ORF6": "#8c564b",
+        "ORF7a": "#e377c2",
+        "ORF7b": "#7f7f7f",
+        "ORF8": "#bcbd22",
+        "N": "#17becf",
+        "ORF10": "#ffbb78",
+    }
+    mutation_color_map = {
+        "missense_variant": "#E6194B",
+        "Unknown": "#A9A9A9",
+        "disruptive_inframe_insertion": "#BFEF45",
+        "frameshift_variant": "#F58231",
+        "splice_region_variant&stop_retained_variant": "#FF8DA1",
+        "conservative_inframe_deletion": "#BF8970",
+        "synonymous_variant": "#4363D8",
+        "stop_lost": "#42D4F4",
+        "frameshift_variant&start_lost": "#F032E6",
+        "start_lost": "#3CB44B",
+        "disruptive_inframe_deletion": "#D4AF37",
+        "gene_fusion": "#469990",
+        "conservative_inframe_insertion": "#DCBEFF",
+        "stop_gained": "#9A6324",
+        "upstream_gene_variant": "#911EB4",
+        "frameshift_variant&stop_lost&splice_region_variant": "#800000",
+        "frameshift_variant&stop_gained": "#A65628",
+        "stop_retained_variant": "#FF6347",
+        "downstream_gene_variant": "#808000",
+    }
+
+    x_values = [int(x) for x in mdata.get("x", [])]
+    y_values = list(mdata.get("y", []))
+    mutation_groups = list(mdata.get("mutationGroups", []))
+    domains = [dict(domain) for domain in mdata.get("domains", [])]
+    max_len = min(len(x_values), len(y_values), len(mutation_groups))
+    x_values = x_values[:max_len]
+    y_values = y_values[:max_len]
+    mutation_groups = mutation_groups[:max_len]
+
+    fig = go.Figure()
+    if toggle_rangeslider == ["on"]:
+        fig.update_layout(
+            xaxis_rangeslider=dict(visible=True, bgcolor="rgba(255, 255, 255, 0)")
         )
-        for domain in sorted_domains:
-            start, end = map(int, domain["coord"].split("-"))
-            domain_selectors.append(
-                dict(
-                    label=domain["name"],
-                    method="relayout",
-                    args=[
-                        {
-                            "xaxis.range": [start, end],
-                        }
-                    ],
-                )
-            )
-            max_pos = max(max_pos, end)
-            fig.add_shape(
-                type="rect",
-                x0=start,
-                x1=end,
-                y0=0,
-                y1=-0.12,
-                fillcolor=domain_color_map.get(domain["name"], "lightgray"),
-                opacity=0.3,
-                layer="below",
-                line=dict(width=0),
-            )
-            # Define a threshold for spacing relative to the x range. I used 0.04 ad-hoc
-            x_space_threshold = x_range * 0.05
+    if relayout_data and "xaxis.range" in relayout_data:
+        min_x, max_x = relayout_data["xaxis.range"]
+        fig.update_layout(xaxis=dict(range=relayout_data["xaxis.range"]))
+    else:
+        min_x, max_x = (min(x_values), max(x_values))
 
-            # Determine an appropriate y-level to avoid overlap
-            annotation_x = (start + end) / 2  # Place annotation in the middle
-            annotation_y = -0.06  # Default y-level
-
-            for prev_x, _ in used_annotations:
-                if abs(annotation_x - prev_x) < x_space_threshold:
-                    domain["name"] = ""  # Do not show annotation if it would overlap
-                    break
-            else:
-                # Store the adjusted position if the annotation is used
-                used_annotations.append((annotation_x, annotation_y))
-
-            # Add text labels for domains
-            fig.add_annotation(
-                x=annotation_x,
-                y=annotation_y,
-                text=domain["name"],
-                showarrow=False,
-                font=dict(size=12, color="black"),
+    x_range = max_x - min_x if max_x > min_x else 1
+    max_pos = 0
+    used_annotations = []
+    all_max_x = max([int(x["coord"].split("-")[1]) for x in domains]) if domains else max_x
+    domain_selectors = [
+        dict(
+            label="All",
+            method="relayout",
+            args=[{"xaxis.range": [0, all_max_x]}],
+        )
+    ]
+    sorted_domains = sorted(domains, key=lambda x: int(x["coord"].split("-")[0]))
+    for domain in sorted_domains:
+        start, end = map(int, domain["coord"].split("-"))
+        domain_selectors.append(
+            dict(
+                label=domain["name"],
+                method="relayout",
+                args=[{"xaxis.range": [start, end]}],
             )
+        )
+        max_pos = max(max_pos, end)
         fig.add_shape(
             type="rect",
-            x0=0,
-            x1=max_pos,
+            x0=start,
+            x1=end,
             y0=0,
             y1=-0.12,
-            fillcolor="lightgray",
+            fillcolor=domain_color_map.get(domain["name"], "lightgray"),
             opacity=0.3,
             layer="below",
             line=dict(width=0),
         )
-        # Filter mutations based on selected range
-        filtered_indices = [i for i, x in enumerate(mdata["x"]) if min_x <= x <= max_x]
+        x_space_threshold = x_range * 0.05
+        annotation_x = (start + end) / 2
+        annotation_y = -0.06
 
-        filtered_x = [mdata["x"][i] for i in filtered_indices]
-        filtered_y = [mdata["y"][i] for i in filtered_indices]
-        filtered_mutation_groups = [
-            mdata["mutationGroups"][i] for i in filtered_indices
-        ]
+        for prev_x, _ in used_annotations:
+            if abs(annotation_x - prev_x) < x_space_threshold:
+                domain["name"] = ""
+                break
+        else:
+            used_annotations.append((annotation_x, annotation_y))
 
-        mutation_traces = {}
-        for x, y, mutation_type in zip(
-            filtered_x, filtered_y, filtered_mutation_groups
-        ):
-            if mutation_type is None:
-                mutation_type = "Unknown"
-            color = mutation_color_map.get(mutation_type)
-
-            if mutation_type not in mutation_traces:
-                mutation_traces[mutation_type] = {
-                    "x_points": [],
-                    "y_points": [],
-                    "x_lines": [],
-                    "y_lines": [],
-                    "color": color,
-                }
-
-            # Add mutation marker
-            mutation_traces[mutation_type]["x_points"].append(int(x))
-            mutation_traces[mutation_type]["y_points"].append(y)
-
-            # Ensure each line (needle) is positioned at its own location
-            mutation_traces[mutation_type]["x_lines"].extend(
-                [int(x), int(x), None]
-            )  # None for breaks
-            mutation_traces[mutation_type]["y_lines"].extend(
-                [-0.005, y, None]
-            )  # None for breaks
-
-        # Add traces for each mutation type
-        for mutation_type, data in mutation_traces.items():
-            # Line trace for needles
-            fig.add_trace(
-                go.Scatter(
-                    x=data["x_lines"],
-                    y=data["y_lines"],
-                    mode="lines",
-                    line=dict(color=data["color"], width=1),
-                    name=mutation_type,  # Legend entry (same as marker)
-                    legendgroup=mutation_type,  # group legend with markers
-                    showlegend=False,  # Hide extra legend entry for lines
-                )
-            )
-
-            # Marker trace for mutation points
-            fig.add_trace(
-                go.Scatter(
-                    x=data["x_points"],
-                    y=data["y_points"],
-                    mode="markers",
-                    marker=dict(size=10, color=data["color"]),
-                    legendgroup=mutation_type,  # Group legend with lines
-                    name=mutation_type,  # Legend entry
-                )
-            )
-        fig.update_layout(
-            title={
-                "text": "Needle Plot",
-                "x": 0.1,
-                "xanchor": "left",
-            },
-            xaxis=dict(
-                title="Genome Position",
-                tickmode="auto",
-                automargin=True,
-                tickformat="d",
-                showgrid=False,
-                zeroline=False,
-                range=[min_x, max_x],
-                rangeselector=dict(),
-            ),
-            paper_bgcolor="white",
-            plot_bgcolor="white",
-            yaxis_title="Allele Frequency",
-            yaxis_range=[-0.12, 1.15],
-            updatemenus=[
-                dict(
-                    type="buttons",
-                    direction="right",
-                    x=0,
-                    y=1.15,
-                    xanchor="left",
-                    showactive=True,
-                    buttons=domain_selectors,
-                )
-            ],
+        fig.add_annotation(
+            x=annotation_x,
+            y=annotation_y,
+            text=domain["name"],
+            showarrow=False,
+            font=dict(size=12, color="black"),
         )
-        return fig, markdown_text, next_data
+    fig.add_shape(
+        type="rect",
+        x0=0,
+        x1=max_pos or max_x,
+        y0=0,
+        y1=-0.12,
+        fillcolor="lightgray",
+        opacity=0.3,
+        layer="below",
+        line=dict(width=0),
+    )
 
-    return app
+    filtered_indices = [i for i, x in enumerate(x_values) if min_x <= x <= max_x]
+    mutation_traces = {}
+    for idx in filtered_indices:
+        mutation_type = mutation_groups[idx] or "Unknown"
+        color = mutation_color_map.get(mutation_type, "#6c757d")
+        mutation_traces.setdefault(
+            mutation_type,
+            {"x_points": [], "y_points": [], "x_lines": [], "y_lines": [], "color": color},
+        )
+        mutation_traces[mutation_type]["x_points"].append(int(x_values[idx]))
+        mutation_traces[mutation_type]["y_points"].append(y_values[idx])
+        mutation_traces[mutation_type]["x_lines"].extend([int(x_values[idx]), int(x_values[idx]), None])
+        mutation_traces[mutation_type]["y_lines"].extend([-0.005, y_values[idx], None])
+
+    for mutation_type, data in mutation_traces.items():
+        fig.add_trace(
+            go.Scatter(
+                x=data["x_lines"],
+                y=data["y_lines"],
+                mode="lines",
+                line=dict(color=data["color"], width=1),
+                name=mutation_type,
+                legendgroup=mutation_type,
+                showlegend=False,
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=data["x_points"],
+                y=data["y_points"],
+                mode="markers",
+                marker=dict(size=10, color=data["color"]),
+                legendgroup=mutation_type,
+                name=mutation_type,
+            )
+        )
+
+    fig.update_layout(
+        title={"text": "Needle Plot", "x": 0.1, "xanchor": "left"},
+        xaxis=dict(
+            title="Genome Position",
+            tickmode="auto",
+            automargin=True,
+            tickformat="d",
+            showgrid=False,
+            zeroline=False,
+            range=[min_x, max_x],
+            rangeselector=dict(),
+        ),
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        yaxis_title="Allele Frequency",
+        yaxis_range=[-0.12, 1.15],
+        updatemenus=[
+            dict(
+                type="buttons",
+                direction="right",
+                x=0,
+                y=1.15,
+                xanchor="left",
+                showactive=True,
+                buttons=domain_selectors,
+            )
+        ],
+    )
+    return fig
 
 
 def log_ydata_if_needed(graph, ydata, ratio=100):

--- a/core/utils/plotly_graphics.py
+++ b/core/utils/plotly_graphics.py
@@ -308,7 +308,9 @@ def build_sample_variant_figure(mdata, toggle_rangeslider=None, relayout_data=No
     x_range = max_x - min_x if max_x > min_x else 1
     max_pos = 0
     used_annotations = []
-    all_max_x = max([int(x["coord"].split("-")[1]) for x in domains]) if domains else max_x
+    all_max_x = (
+        max([int(x["coord"].split("-")[1]) for x in domains]) if domains else max_x
+    )
     domain_selectors = [
         dict(
             label="All",
@@ -375,11 +377,19 @@ def build_sample_variant_figure(mdata, toggle_rangeslider=None, relayout_data=No
         color = mutation_color_map.get(mutation_type, "#6c757d")
         mutation_traces.setdefault(
             mutation_type,
-            {"x_points": [], "y_points": [], "x_lines": [], "y_lines": [], "color": color},
+            {
+                "x_points": [],
+                "y_points": [],
+                "x_lines": [],
+                "y_lines": [],
+                "color": color,
+            },
         )
         mutation_traces[mutation_type]["x_points"].append(int(x_values[idx]))
         mutation_traces[mutation_type]["y_points"].append(y_values[idx])
-        mutation_traces[mutation_type]["x_lines"].extend([int(x_values[idx]), int(x_values[idx]), None])
+        mutation_traces[mutation_type]["x_lines"].extend(
+            [int(x_values[idx]), int(x_values[idx]), None]
+        )
         mutation_traces[mutation_type]["y_lines"].extend([-0.005, y_values[idx], None])
 
     for mutation_type, data in mutation_traces.items():

--- a/core/utils/samples.py
+++ b/core/utils/samples.py
@@ -387,8 +387,17 @@ def create_dash_bar_for_each_lab(labs_data, labs_list=None):
             )
             _add_option(value, label)
 
-    core.utils.plotly_dash_graphics.dash_bar_lab(normalised_options, df_data)
-    return
+    default_value = normalised_options[0]["value"] if normalised_options else None
+    records = df_data.to_dict("records")
+    return {
+        "select_collecting_inst": {
+            "options": normalised_options,
+            "value": default_value,
+        },
+        "sample_per_lab_data": {
+            "data": records,
+        },
+    }
 
 
 def fancy_gauge_graphic(value):

--- a/core/utils/samples_map.py
+++ b/core/utils/samples_map.py
@@ -89,15 +89,11 @@ def build_samples_received_map_html():
         ),
     ).add_to(m)
 
-    m.get_root().html.add_child(
-        folium.Element(
-            """
+    m.get_root().html.add_child(folium.Element("""
     <style>
         .leaflet-interactive:focus { outline: none !important; box-shadow: none !important; }
     </style>
-    """
-        )
-    )
+    """))
 
     return m.get_root().render()
 

--- a/core/utils/samples_map.py
+++ b/core/utils/samples_map.py
@@ -89,11 +89,15 @@ def build_samples_received_map_html():
         ),
     ).add_to(m)
 
-    m.get_root().html.add_child(folium.Element("""
+    m.get_root().html.add_child(
+        folium.Element(
+            """
     <style>
         .leaflet-interactive:focus { outline: none !important; box-shadow: none !important; }
     </style>
-    """))
+    """
+        )
+    )
 
     return m.get_root().render()
 

--- a/core/utils/samples_map.py
+++ b/core/utils/samples_map.py
@@ -1,17 +1,16 @@
-# Generic imports
-import os
 import json
+import os
+
 import folium
-from dash import html
-from django_plotly_dash import DjangoDash
 import pandas as pd
 
 # Local imports
+import dashboard.utils.generic_graphic_data
+import dashboard.utils.generic_process_data
 from relecov_platform import settings as relecov_platform_settings
-import dashboard.models
 
 
-def create_samples_received_map():
+def build_samples_received_map_html():
     geojson_file = os.path.join(
         relecov_platform_settings.STATIC_ROOT,
         "dashboard",
@@ -96,13 +95,11 @@ def create_samples_received_map():
     </style>
     """))
 
-    # Generar el HTML del mapa
-    map_html = m.get_root().render()
+    return m.get_root().render()
 
-    # Reemplazar el gráfico de Plotly por Folium en DjangoDash
-    app = DjangoDash("samplesReceivedOverTimeMap")
-    app.layout = html.Div(
-        children=[
-            html.Iframe(srcDoc=map_html, style={"width": "100%", "height": "800px"}),
-        ],
-    )
+
+def create_samples_received_map():
+    result = build_samples_received_map_html()
+    if isinstance(result, dict) and "ERROR" in result:
+        return result
+    return {"OK": True}

--- a/core/utils/variants.py
+++ b/core/utils/variants.py
@@ -135,7 +135,7 @@ def get_variant_graphic_from_sample(sample_id):
         # delete no longer needed ids
         v_data.pop("v_id")
 
-    return core.utils.plotly_graphics.needle_plot(v_data)
+    return core.utils.plotly_graphics.build_sample_variant_initial_arguments(v_data)
 
 
 def get_gene_obj_from_gene_name(gene_name):

--- a/core/views.py
+++ b/core/views.py
@@ -309,8 +309,10 @@ def intranet(request):
                 )
                 lablist.append({"value": value, "label": label or value})
             if len(lablist) > 1:
-                core.utils.samples.create_dash_bar_for_each_lab(
+                intra_data["sample_per_lab_initial_arguments"] = (
+                    core.utils.samples.create_dash_bar_for_each_lab(
                     clean_samples_per_date_detailed, lablist
+                    )
                 )
                 intra_data["show_per_lab_dash"] = True
             else:
@@ -401,8 +403,10 @@ def intranet(request):
                 {k: v for k, v in d.items() if k != "submitting_institution"}
                 for d in all_sample_per_date_detailed
             ]
-            core.utils.samples.create_dash_bar_for_each_lab(
+            manager_intra_data["sample_per_lab_initial_arguments"] = (
+                core.utils.samples.create_dash_bar_for_each_lab(
                 clean_samples_per_date_detailed, all_labs
+                )
             )
             # Get the latest action from each lab
             manager_intra_data["actions"] = core.utils.samples.get_lab_last_actions()

--- a/core/views.py
+++ b/core/views.py
@@ -311,7 +311,7 @@ def intranet(request):
             if len(lablist) > 1:
                 intra_data["sample_per_lab_initial_arguments"] = (
                     core.utils.samples.create_dash_bar_for_each_lab(
-                    clean_samples_per_date_detailed, lablist
+                        clean_samples_per_date_detailed, lablist
                     )
                 )
                 intra_data["show_per_lab_dash"] = True
@@ -405,7 +405,7 @@ def intranet(request):
             ]
             manager_intra_data["sample_per_lab_initial_arguments"] = (
                 core.utils.samples.create_dash_bar_for_each_lab(
-                clean_samples_per_date_detailed, all_labs
+                    clean_samples_per_date_detailed, all_labs
                 )
             )
             # Get the latest action from each lab

--- a/dashboard/apps.py
+++ b/dashboard/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class RelecovDashboardConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "dashboard"
+
+    def ready(self):
+        from dashboard.dash_apps import register_all
+
+        register_all()

--- a/dashboard/dash_apps/__init__.py
+++ b/dashboard/dash_apps/__init__.py
@@ -1,3 +1,5 @@
+from .heatmap_lineage import register as register_heatmap_lineage
+from .mutation_table import register as register_mutation_table
 from .needle_lineage import register as register_needle_lineage
 from .variation_lineage import register as register_variation_lineage
 
@@ -8,6 +10,8 @@ def register_all():
     global _REGISTERED
     if _REGISTERED:
         return
+    register_heatmap_lineage()
+    register_mutation_table()
     register_needle_lineage()
     register_variation_lineage()
     _REGISTERED = True

--- a/dashboard/dash_apps/__init__.py
+++ b/dashboard/dash_apps/__init__.py
@@ -1,0 +1,13 @@
+from .needle_lineage import register as register_needle_lineage
+from .variation_lineage import register as register_variation_lineage
+
+_REGISTERED = False
+
+
+def register_all():
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    register_needle_lineage()
+    register_variation_lineage()
+    _REGISTERED = True

--- a/dashboard/dash_apps/heatmap_lineage.py
+++ b/dashboard/dash_apps/heatmap_lineage.py
@@ -1,0 +1,77 @@
+from dash import dcc, html
+from dash.dependencies import Input, Output
+from django_plotly_dash import DjangoDash
+
+import dashboard.utils.var_heatmap_mutation_graph_by_lineage
+
+APP_NAME = "mutationHeatmap"
+
+
+def register():
+    app = DjangoDash(APP_NAME)
+
+    def serve_layout():
+        sample_ids, genes = (
+            dashboard.utils.var_heatmap_mutation_graph_by_lineage.get_heatmap_options()
+        )
+        figure = dashboard.utils.var_heatmap_mutation_graph_by_lineage.create_heatmap(
+            sample_ids, genes
+        )
+        return html.Div(
+            children=[
+                html.Div(
+                    style={
+                        "display": "flex",
+                        "justify-content": "space-between",
+                        "align-items": "flex-start",
+                    },
+                    children=[
+                        html.P("Select samples"),
+                        html.P("Select genes"),
+                    ],
+                ),
+                html.Div(
+                    style={
+                        "display": "flex",
+                        "justify-content": "start",
+                        "align-items": "flex-start",
+                    },
+                    children=[
+                        dcc.Dropdown(
+                            id="mutation_heatmap_select_sample",
+                            options=[{"label": i, "value": i} for i in sample_ids],
+                            clearable=False,
+                            multi=True,
+                            value=sample_ids,
+                            style={"width": "390px", "margin-right": "30px"},
+                        ),
+                        dcc.Dropdown(
+                            id="mutation_heatmap_gene_dropdown",
+                            options=[{"label": i, "value": i} for i in genes],
+                            clearable=False,
+                            multi=True,
+                            value=genes,
+                            style={"width": "390px", "margin-right": "35px"},
+                        ),
+                    ],
+                ),
+                dcc.Graph(
+                    id="mutation_heatmap_graph",
+                    figure=figure,
+                ),
+            ]
+        )
+
+    app.layout = serve_layout
+
+    @app.callback(
+        Output("mutation_heatmap_graph", "figure"),
+        Input("mutation_heatmap_select_sample", "value"),
+        Input("mutation_heatmap_gene_dropdown", "value"),
+    )
+    def update_selected_sample(selected_sample, selected_genes):
+        selected_sample = list(selected_sample or [])
+        selected_genes = list(selected_genes or [])
+        return dashboard.utils.var_heatmap_mutation_graph_by_lineage.create_heatmap(
+            selected_sample, selected_genes
+        )

--- a/dashboard/dash_apps/mutation_table.py
+++ b/dashboard/dash_apps/mutation_table.py
@@ -1,0 +1,62 @@
+from dash import dash_table, dcc, html
+from dash.dependencies import Input, Output
+from django_plotly_dash import DjangoDash
+
+import dashboard.utils.var_lineages_mutation_table_generation
+
+APP_NAME = "mutationTable"
+PAGE_SIZE = 20
+
+
+def register():
+    app = DjangoDash(APP_NAME)
+
+    def serve_layout():
+        sample_ids, effects = (
+            dashboard.utils.var_lineages_mutation_table_generation.get_default_sample_and_effect_options()
+        )
+        data = dashboard.utils.var_lineages_mutation_table_generation.create_mutation_table(
+            sample_ids, effects
+        )
+        columns = [{"name": key, "id": key} for key in data[0].keys()] if data else []
+        return html.Div(
+            children=[
+                html.P("Select effects"),
+                dcc.Dropdown(
+                    id="mutation_table-effect_dropdown",
+                    options=[{"label": i, "value": i} for i in effects],
+                    clearable=False,
+                    multi=True,
+                    value=effects,
+                    style={"width": "400px"},
+                    placeholder="Mutation effect",
+                ),
+                html.Br(),
+                dash_table.DataTable(
+                    id="mutation_datatable",
+                    data=data,
+                    columns=columns,
+                    page_current=0,
+                    page_size=PAGE_SIZE,
+                    page_action="custom",
+                ),
+            ]
+        )
+
+    app.layout = serve_layout
+
+    @app.callback(
+        Output("mutation_datatable", "data"),
+        Output("mutation_datatable", "columns"),
+        Input("mutation_table-effect_dropdown", "value"),
+    )
+    def update_selected_effects(selected_effects):
+        sample_ids, _ = (
+            dashboard.utils.var_lineages_mutation_table_generation.get_default_sample_and_effect_options()
+        )
+        selected_effects = list(selected_effects or [])
+        data = dashboard.utils.var_lineages_mutation_table_generation.create_mutation_table(
+            sample_ids, selected_effects
+        )
+        columns = [{"name": key, "id": key} for key in data[0].keys()] if data else []
+        return data, columns

--- a/dashboard/dash_apps/needle_lineage.py
+++ b/dashboard/dash_apps/needle_lineage.py
@@ -1,0 +1,105 @@
+from dash import dcc, html
+from dash.dependencies import Input, Output
+from django_plotly_dash import DjangoDash
+
+import dashboard.utils.var_needle_mutation_graph_by_lineage
+
+
+APP_NAME = "needlePlotMutationByLineage"
+
+
+def register():
+    app = DjangoDash(
+        APP_NAME,
+        external_stylesheets=[
+            "https://fonts.googleapis.com/css2?family=Oxanium&display=swap",
+            "/static/core/css/dash_style.css",
+        ],
+    )
+
+    app.layout = html.Div(
+        children=[
+            html.Div(
+                children=[
+                    html.Div(
+                        children=[
+                            "Select Lineage",
+                            dcc.Dropdown(
+                                id="needleplot-select-lineage",
+                                options=[],
+                                clearable=False,
+                                multi=False,
+                                value=None,
+                                style={"width": "150px", "margin-right": "30px"},
+                            ),
+                        ],
+                        style={"margin-left": "20px"},
+                    ),
+                    html.Div(
+                        [
+                            "Show Range Slider",
+                            dcc.Checklist(
+                                id="toggle-rangeslider",
+                                options=[{"label": "Enable", "value": "on"}],
+                                value=["on"],
+                                inline=True,
+                            ),
+                        ],
+                        style={"margin-left": "20px"},
+                    ),
+                    html.Div(
+                        children=[dcc.Markdown(id="samples_markdown")],
+                        style={"margin-left": "50px"},
+                    ),
+                ],
+                style={
+                    "display": "flex",
+                    "justify-content": "start",
+                    "align-items": "flex-start",
+                },
+            ),
+            html.Div(
+                children=[
+                    dcc.Loading(
+                        id="loading_plot_wrapper",
+                        type="default",
+                        children=[
+                            html.Div(
+                                id="needleplot-container-div",
+                                children=[
+                                    dcc.Graph(
+                                        id="needleplot-graph",
+                                        style={"padding-top": "15px"},
+                                        figure=dashboard.utils.var_needle_mutation_graph_by_lineage.empty_needle_plot_figure(),
+                                    ),
+                                ],
+                                style={"position": "relative"},
+                            )
+                        ],
+                        overlay_style={"visibility": "visible", "filter": "blur(1px)"},
+                        parent_style={"position": "relative"},
+                    ),
+                ],
+            ),
+        ]
+    )
+
+    @app.callback(
+        [Output("needleplot-graph", "figure"), Output("samples_markdown", "children")],
+        [
+            Input("needleplot-select-lineage", "value"),
+            Input("toggle-rangeslider", "value"),
+            Input("needleplot-graph", "relayoutData"),
+        ],
+    )
+    def update_sample(selected_lineage, toggle_rangeslider, relayout_data):
+        if not selected_lineage:
+            return (
+                dashboard.utils.var_needle_mutation_graph_by_lineage.empty_needle_plot_figure(),
+                "No lineage selected",
+            )
+        return dashboard.utils.var_needle_mutation_graph_by_lineage.build_needle_plot_figure(
+            selected_lineage,
+            toggle_rangeslider=toggle_rangeslider,
+            relayout_data=relayout_data,
+        )

--- a/dashboard/dash_apps/needle_lineage.py
+++ b/dashboard/dash_apps/needle_lineage.py
@@ -4,7 +4,6 @@ from django_plotly_dash import DjangoDash
 
 import dashboard.utils.var_needle_mutation_graph_by_lineage
 
-
 APP_NAME = "needlePlotMutationByLineage"
 
 

--- a/dashboard/dash_apps/variation_lineage.py
+++ b/dashboard/dash_apps/variation_lineage.py
@@ -34,7 +34,9 @@ def _build_empty_figure():
 
 
 def register():
-    data_df = dashboard.utils.var_lineage_variation_over_time_graph.load_variant_graphic_dataframe()
+    data_df = (
+        dashboard.utils.var_lineage_variation_over_time_graph.load_variant_graphic_dataframe()
+    )
     if isinstance(data_df, dict) or data_df.empty:
         first_date = None
         last_date = None
@@ -42,15 +44,11 @@ def register():
     else:
         first_date = data_df["Collection date"].min()
         last_date = data_df["Collection date"].max()
-        df_full = (
-            dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
-                data_df
-            )
+        df_full = dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
+            data_df
         )
-        initial_figure = (
-            dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
-                df_full
-            )
+        initial_figure = dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
+            df_full
         )
 
     app = DjangoDash(
@@ -111,13 +109,13 @@ def register():
         [Input("datePickerRange", "start_date"), Input("datePickerRange", "end_date")],
     )
     def update_graph(start_date, end_date):
-        data_df = dashboard.utils.var_lineage_variation_over_time_graph.load_variant_graphic_dataframe()
+        data_df = (
+            dashboard.utils.var_lineage_variation_over_time_graph.load_variant_graphic_dataframe()
+        )
         if isinstance(data_df, dict) or data_df.empty:
             return initial_figure
-        df_full = (
-            dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
-                data_df
-            )
+        df_full = dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
+            data_df
         )
         return dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
             df_full, start_date=start_date, end_date=end_date

--- a/dashboard/dash_apps/variation_lineage.py
+++ b/dashboard/dash_apps/variation_lineage.py
@@ -1,0 +1,124 @@
+import dash_bootstrap_components as dbc
+from dash import dcc, html
+from dash.dependencies import Input, Output
+from django_plotly_dash import DjangoDash
+
+import dashboard.utils.var_lineage_variation_over_time_graph
+
+
+APP_NAME = "variationLineageOverTime"
+
+
+def _build_empty_figure():
+    data_df = (
+        dashboard.utils.var_lineage_variation_over_time_graph.load_variant_graphic_dataframe()
+    )
+    if isinstance(data_df, dict) and "ERROR" in data_df:
+        return dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
+            dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
+                data_df
+            )
+        )
+    if data_df.empty:
+        return dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
+            dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
+                data_df
+            )
+        )
+    df_full = dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
+        data_df
+    )
+    return dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
+        df_full
+    )
+
+
+def register():
+    data_df = dashboard.utils.var_lineage_variation_over_time_graph.load_variant_graphic_dataframe()
+    if isinstance(data_df, dict) or data_df.empty:
+        first_date = None
+        last_date = None
+        initial_figure = {}
+    else:
+        first_date = data_df["Collection date"].min()
+        last_date = data_df["Collection date"].max()
+        df_full = (
+            dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
+                data_df
+            )
+        )
+        initial_figure = (
+            dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
+                df_full
+            )
+        )
+
+    app = DjangoDash(
+        APP_NAME,
+        external_stylesheets=[dbc.themes.BOOTSTRAP],
+    )
+
+    controls = dbc.Card(
+        [
+            html.Div(
+                [
+                    dbc.Label("Select period of time (MM/DD/YYYY)"),
+                    dcc.DatePickerRange(
+                        id="datePickerRange",
+                        start_date_placeholder_text="Start Date",
+                        end_date_placeholder_text="End Date",
+                        min_date_allowed=first_date,
+                        max_date_allowed=last_date,
+                        calendar_orientation="horizontal",
+                        number_of_months_shown=3,
+                    ),
+                ],
+            ),
+        ],
+        body=True,
+    )
+    period_text = dbc.Card(
+        [
+            html.Div(
+                "When no Selection period is set, data from the first registered date until today is shown"
+            )
+        ]
+    )
+    app.layout = dbc.Container(
+        [
+            dbc.Row(
+                [
+                    dbc.Col(controls, md=4),
+                    dbc.Col(period_text, md=6),
+                    dbc.Col(
+                        dcc.Graph(
+                            id="lineageGraph",
+                            figure=initial_figure,
+                            config={"displaylogo": False},
+                            style={"padding-top": "15px"},
+                        ),
+                        md=12,
+                    ),
+                ],
+                align="center",
+            ),
+        ],
+        fluid=True,
+    )
+
+    @app.callback(
+        Output("lineageGraph", "figure"),
+        [Input("datePickerRange", "start_date"), Input("datePickerRange", "end_date")],
+    )
+    def update_graph(start_date, end_date):
+        data_df = dashboard.utils.var_lineage_variation_over_time_graph.load_variant_graphic_dataframe()
+        if isinstance(data_df, dict) or data_df.empty:
+            return initial_figure
+        df_full = (
+            dashboard.utils.var_lineage_variation_over_time_graph.prepare_variant_graphic_dataframe(
+                data_df
+            )
+        )
+        return dashboard.utils.var_lineage_variation_over_time_graph.build_lineage_variation_figure(
+            df_full, start_date=start_date, end_date=end_date
+        )

--- a/dashboard/dash_apps/variation_lineage.py
+++ b/dashboard/dash_apps/variation_lineage.py
@@ -5,7 +5,6 @@ from django_plotly_dash import DjangoDash
 
 import dashboard.utils.var_lineage_variation_over_time_graph
 
-
 APP_NAME = "variationLineageOverTime"
 
 

--- a/dashboard/templates/dashboard/variantMutationsInLineage.html
+++ b/dashboard/templates/dashboard/variantMutationsInLineage.html
@@ -73,7 +73,7 @@
                                 </div>
                                 <div class="row justify-content-center p-4">
                                     <div class="col-md-12">
-                                        {% plotly_app name="needlePlotMutationByLineage" ratio=1.3 %}
+                                        {% plotly_app name="needlePlotMutationByLineage" ratio=1.3 initial_arguments=needle_plot_initial_arguments %}
                                     </div>
                                 </div>
                                 </div>

--- a/dashboard/utils/var_heatmap_mutation_graph_by_lineage.py
+++ b/dashboard/utils/var_heatmap_mutation_graph_by_lineage.py
@@ -13,13 +13,11 @@ Mutation heatmap
 # Generic imports
 import pandas as pd
 import plotly.express as px
-from dash import dcc, html
-from dash.dependencies import Input, Output
-from django_plotly_dash import DjangoDash
 
 # Local imports
 import core.models
 import core.utils.samples
+import core.utils.variants
 
 
 def create_dataframe(sample_list, gene_list):
@@ -78,7 +76,35 @@ def create_dataframe(sample_list, gene_list):
     return pandas_df
 
 
+def get_default_sample_and_gene_options():
+    chromosome_obj = core.utils.variants.get_default_chromosome()
+    if chromosome_obj is None:
+        return [], []
+    gene_list = core.utils.variants.get_gene_list(chromosome_obj)
+    sample_list = core.utils.variants.get_sample_in_variant_list(chromosome_obj)
+    return sample_list, gene_list
+
+
+def empty_heatmap_figure():
+    fig = px.imshow(
+        [[None]],
+        labels=dict(x="Mutation", y="Sample", color="AF"),
+        color_continuous_scale="RdYlGn",
+        range_color=[0, 1],
+    )
+    fig.update_layout(
+        title="No mutation data available",
+        yaxis={"title": "Samples"},
+        xaxis={"title": "Mutations", "tickangle": 45},
+        layout_coloraxis_showscale=True,
+        layout_showlegend=False,
+    )
+    return fig
+
+
 def get_figure(data: pd.DataFrame, sample_ids: list, genes: list):
+    if data.empty:
+        return empty_heatmap_figure()
     # Order by position
     data = data.sort_values(by=["POS"])
 
@@ -114,72 +140,14 @@ def get_figure(data: pd.DataFrame, sample_ids: list, genes: list):
     return fig
 
 
+def get_heatmap_options():
+    sample_list, gene_list = get_default_sample_and_gene_options()
+    df = create_dataframe(sample_list=sample_list, gene_list=gene_list)
+    all_genes = list(df["GENE"].unique()) if not df.empty else gene_list
+    all_sample_ids = list(df["SAMPLE"].unique()) if not df.empty else sample_list
+    return all_sample_ids, all_genes
+
+
 def create_heatmap(sample_list, gene_list):
     df = create_dataframe(sample_list=sample_list, gene_list=gene_list)
-    get_figure(df, sample_list, genes=gene_list)
-
-    all_genes = list(df["GENE"].unique())
-    all_sample_ids = list(df["SAMPLE"].unique())
-
-    app = DjangoDash("mutationHeatmap")
-    app.layout = html.Div(
-        children=[
-            html.Div(
-                style={
-                    "display": "flex",
-                    "justify-content": "space-between",
-                    "align-items": "flex-start",
-                },
-                children=[
-                    html.P("Select samples"),
-                    html.P("Select genes"),
-                ],
-            ),
-            # html.P("Select samples"),
-            html.Div(
-                style={
-                    "display": "flex",
-                    "justify-content": "start",
-                    "align-items": "flex-start",
-                },
-                children=[
-                    dcc.Dropdown(
-                        id="mutation_heatmap_select_sample",
-                        options=[{"label": i, "value": i} for i in all_sample_ids],
-                        clearable=False,
-                        multi=True,
-                        value=all_sample_ids,
-                        style={"width": "390px", "margin-right": "30px"},
-                        # placeholder="Select samples",
-                    ),
-                    dcc.Dropdown(
-                        # "Select genes",
-                        id="mutation_heatmap_gene_dropdown",
-                        options=[{"label": i, "value": i} for i in all_genes],
-                        clearable=False,
-                        multi=True,
-                        value=all_genes,
-                        style={"width": "390px", "margin-right": "35px"},
-                        # placeholder="Select genes",
-                    ),
-                ],
-            ),
-            dcc.Graph(
-                id="mutation_heatmap_graph",
-                figure=get_figure(df, all_sample_ids, genes=None),
-                # style={"width": "1500px", "height": "700px"},
-            ),
-        ]
-    )
-
-    @app.callback(
-        Output("mutation_heatmap_graph", "figure"),
-        Input("mutation_heatmap_select_sample", "value"),
-        Input("mutation_heatmap_gene_dropdown", "value"),
-    )
-    def update_selected_sample(selected_sample: int, selected_genes):
-        data = create_dataframe(
-            sample_list=list(selected_sample), gene_list=selected_genes
-        )
-        fig = get_figure(data, selected_sample, genes=selected_genes)
-        return fig
+    return get_figure(df, sample_list, genes=gene_list)

--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -1,12 +1,8 @@
 # Generic imports
 from datetime import datetime
 
-import dash_bootstrap_components as dbc
 import pandas as pd
 import plotly.graph_objects as go
-from dash import dcc, html
-from dash.dependencies import Input, Output
-from django_plotly_dash import DjangoDash
 from plotly.subplots import make_subplots
 
 # Local imports
@@ -14,13 +10,11 @@ import dashboard.utils.generic_graphic_data
 import dashboard.utils.generic_process_data
 
 
-def create_lineages_variations_graphic():
-    """Collect the pre-processed data from database"""
+def load_variant_graphic_dataframe():
     json_data = dashboard.utils.generic_graphic_data.get_graphic_json_data(
         "variant_graphic_data"
     )
     if json_data is None:
-        # Execute the pre-processed task to get the data
         result = dashboard.utils.generic_process_data.pre_proc_variant_graphic()
         if "ERROR" in result:
             return result
@@ -28,25 +22,17 @@ def create_lineages_variations_graphic():
             "variant_graphic_data"
         )
 
-    data_df = pd.DataFrame(json_data)
-    data_df = data_df.dropna()
+    data_df = pd.DataFrame(json_data).dropna()
+    if data_df.empty:
+        return data_df
+
     data_df["Collection date"] = pd.to_datetime(data_df["Collection date"])
-    # TODO: Clean database so this date filter is not necessary
     data_df = data_df[data_df["Collection date"] >= "2020-01-01"]
     data_df["samples"] = data_df["samples"].astype(int)
-    app = DjangoDash(
-        "variationLineageOverTime", external_stylesheets=[dbc.themes.BOOTSTRAP]
-    )
-    first_date = data_df["Collection date"].min()
-    last_date = data_df["Collection date"].max()
-    # Order by date to ensure isoweeks are ordered too later on
-    data_df = data_df.sort_values("Collection date")
-    samples_df = pd.DataFrame()
-    samples_df["samples"] = data_df.groupby("Collection date")["samples"].sum()
-    samples_df = samples_df.reset_index()
+    return data_df.sort_values("Collection date")
 
-    lineages = data_df["Lineage"].unique().tolist()
-    # group samples in variants per weeks
+
+def prepare_variant_graphic_dataframe(data_df):
     data_week_df = (
         data_df.groupby(["Lineage", pd.Grouper(key="Collection date", freq="W-MON")])[
             "samples"
@@ -55,14 +41,13 @@ def create_lineages_variations_graphic():
         .reset_index()
         .sort_values("Collection date")
     )
-    # Include all the weeks with no data as 0 samples
+
     full_weeks_as_str = pd.date_range(
         data_week_df["Collection date"].min(),
         data_week_df["Collection date"].max(),
         freq="W-MON",
     ).strftime("%G-W%V-%u")
 
-    # Create a full DataFrame with the combination of all Lineages and all possible weeks
     df_full = pd.MultiIndex.from_product(
         [data_week_df["Lineage"].unique(), full_weeks_as_str],
         names=["Lineage", "Collection date"],
@@ -71,196 +56,55 @@ def create_lineages_variations_graphic():
         df_full["Collection date"], format="%G-W%V-%u"
     )
 
-    # Merge with the original data and fill missing values with 0
     df_full = df_full.merge(
         data_week_df, on=["Lineage", "Collection date"], how="left"
     ).fillna(0)
+    df_full["samples"] = df_full["samples"].astype(int)
+    return df_full
 
-    controls = dbc.Card(
-        [
-            html.Div(
-                [
-                    dbc.Label("Select period of time (MM/DD/YYYY)"),
-                    dcc.DatePickerRange(
-                        id="datePickerRange",
-                        start_date_placeholder_text="Start Date",
-                        end_date_placeholder_text="End Date",
-                        min_date_allowed=first_date,
-                        max_date_allowed=last_date,
-                        calendar_orientation="horizontal",
-                        number_of_months_shown=3,
-                    ),
-                ],
-            ),
-        ],
-        body=True,
-    )
-    period_text = dbc.Card(
-        [
-            html.Div(
-                "When no Selection period is set, data from the first registered date until today is shown"
-            )
-        ]
-    )
-    app.layout = dbc.Container(
-        [
-            dbc.Row(
-                [
-                    dbc.Col(controls, md=4),
-                    dbc.Col(period_text, md=6),
-                    dbc.Col(
-                        dcc.Graph(
-                            id="lineageGraph",
-                            figure="",
-                            config={"displaylogo": False},
-                            style={"padding-top": "15px"},
-                        ),
-                        md=12,
-                    ),
-                ],
-                align="center",
-            ),
-        ],
-        fluid=True,
-    )
 
-    @app.callback(
-        Output("lineageGraph", "figure"),
-        [Input("datePickerRange", "start_date"), Input("datePickerRange", "end_date")],
-    )
-    def update_graph(start_date, end_date):
-        if start_date is None or end_date is None:
-            # Select the samples from all registered years
-            sub_data_df = df_full.loc[
-                (df_full["Collection date"] >= first_date)
-                & (df_full["Collection date"] < last_date)
-            ]
+def build_lineage_variation_figure(df_full, start_date=None, end_date=None):
+    lineages = df_full["Lineage"].unique().tolist()
+    first_date = df_full["Collection date"].min()
+    last_date = df_full["Collection date"].max()
 
-        else:
-            start_date_obj = datetime.strptime(start_date, "%Y-%m-%d")
-            end_date_obj = datetime.strptime(end_date, "%Y-%m-%d")
-            sub_data_df = df_full.loc[
-                (df_full["Collection date"] >= start_date_obj)
-                & (df_full["Collection date"] < end_date_obj)
-            ]
+    if start_date is None or end_date is None:
+        sub_data_df = df_full.loc[
+            (df_full["Collection date"] >= first_date)
+            & (df_full["Collection date"] < last_date)
+        ].copy()
+    else:
+        start_date_obj = datetime.strptime(start_date, "%Y-%m-%d")
+        end_date_obj = datetime.strptime(end_date, "%Y-%m-%d")
+        sub_data_df = df_full.loc[
+            (df_full["Collection date"] >= start_date_obj)
+            & (df_full["Collection date"] < end_date_obj)
+        ].copy()
 
-        sub_data_df["Collection ISOWeek"] = sub_data_df["Collection date"].dt.strftime(
-            "%Y-W%V"
+    fig = make_subplots(specs=[[{"secondary_y": True}]])
+    if sub_data_df.empty:
+        fig.add_trace(go.Scatter())
+        fig.add_annotation(
+            text="No samples found for the selected dates",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            showarrow=False,
+            font=dict(size=20, color="red"),
         )
-
-        graph_df = sub_data_df.pivot_table(
-            index="Collection ISOWeek",
-            columns="Lineage",
-            values="samples",
-            aggfunc="sum",
-            fill_value=0,
-        )
-
-        # remove the sample text from column
-        graph_df = graph_df.fillna(0)
-        # Convert values to integer
-        graph_df[lineages] = graph_df[lineages].astype(int)
-        # Do the percentage calculation
-        value_per_df = (graph_df.div(graph_df.sum(axis=1), axis=0) * 100).round(2)
-        value_per_df = value_per_df.fillna(0)
-        samples_per_week = graph_df.sum(axis=1)
-        # Create figure with secondary y-axis
-        fig = make_subplots(specs=[[{"secondary_y": True}]])
-        if sub_data_df.empty:
-            fig.add_trace(go.Scatter())
-            fig.add_annotation(
-                text="No samples found for the selected dates",
-                xref="paper",
-                yref="paper",
-                x=0.5,
-                y=0.5,
-                showarrow=False,
-                font=dict(size=20, color="red"),
-            )
-            fig.update_layout(
-                xaxis=dict(showline=True, linecolor="black", linewidth=2, mirror=True),
-                yaxis=dict(showline=True, linecolor="black", linewidth=2, mirror=True),
-                barmode="stack",
-                hovermode="x unified",
-                legend_xanchor="center",  # use center of legend as anchor
-                legend_yanchor="top",
-                legend_orientation="h",  # show entries horizontally
-                legend_x=0.5,  # put legend in center of x-axis
-                legend_y=-0.30,
-                bargap=0,  # gap between bars of adjacent location coordinates.
-                bargroupgap=0,  # gap between bars of the same location coordinate.
-                margin_l=10,
-                margin_r=10,
-                margin_b=40,
-                margin_t=40,
-                height=600,
-                paper_bgcolor="white",
-                plot_bgcolor="white",
-            )
-            return fig
-        hover_text = [f"{y}" for y in samples_per_week.values]
-        fig.add_trace(
-            go.Scatter(
-                x=value_per_df.index,
-                y=samples_per_week,
-                hoverinfo="text",
-                hovertemplate="%{text}",
-                mode="lines",
-                name="Number of samples",
-                line_color="#0066cc",
-                line_width=2,
-                text=hover_text,
-            ),
-            secondary_y=True,
-        )
-        for lineage in lineages:
-            # Setting hovertext to show values > 0 in bold
-            hover_text = [
-                (
-                    f"<b>{lineage}: {y}%</b><extra></extra>"
-                    if y > 0
-                    else f"{lineage}: {y}%<extra></extra>"
-                )
-                for y in value_per_df[lineage].values
-            ]
-            fig.add_trace(
-                go.Scatter(
-                    x=value_per_df.index,
-                    y=value_per_df[lineage],
-                    hoverinfo="text",
-                    hovertemplate="%{text}",
-                    mode="lines",
-                    name=lineage,
-                    opacity=0.7,
-                    stackgroup="variants",
-                    text=hover_text,
-                ),
-                secondary_y=False,
-            )
-        # Set x-axis title
-        fig.update_xaxes(
-            title="Collection Date (ISOweeks)",
-        )
-        # Set y-axes titles
-        fig.update_yaxes(
-            range=[0, 100], title_text="<b>Lineage % relative", secondary_y=False
-        )
-        fig.update_yaxes(
-            title_text="<b>Number of samples processed</b>", secondary_y=True
-        )
-        # Add figure title
         fig.update_layout(
-            title_text="Variants over the selected period",
-            autotypenumbers="convert types",
+            xaxis=dict(showline=True, linecolor="black", linewidth=2, mirror=True),
+            yaxis=dict(showline=True, linecolor="black", linewidth=2, mirror=True),
             barmode="stack",
             hovermode="x unified",
-            legend_xanchor="center",  # use center of legend as anchor
+            legend_xanchor="center",
             legend_yanchor="top",
-            legend_orientation="h",  # show entries horizontally
-            legend_x=0.5,  # put legend in center of x-axis
+            legend_orientation="h",
+            legend_x=0.5,
             legend_y=-0.30,
-            bargap=0,  # gap between bars of adjacent location coordinates.
-            bargroupgap=0,  # gap between bars of the same location coordinate.
+            bargap=0,
+            bargroupgap=0,
             margin_l=10,
             margin_r=10,
             margin_b=40,
@@ -268,14 +112,106 @@ def create_lineages_variations_graphic():
             height=600,
             paper_bgcolor="white",
             plot_bgcolor="white",
-            xaxis=dict(showline=True, linecolor="black", linewidth=2, mirror=True),
-            yaxis=dict(
-                showline=True,
-                linecolor="black",
-                linewidth=2,
-                mirror=True,
-                ticksuffix=" ",
-            ),
-            yaxis2_tickprefix=" ",
         )
         return fig
+
+    sub_data_df["Collection ISOWeek"] = sub_data_df["Collection date"].dt.strftime(
+        "%Y-W%V"
+    )
+
+    graph_df = sub_data_df.pivot_table(
+        index="Collection ISOWeek",
+        columns="Lineage",
+        values="samples",
+        aggfunc="sum",
+        fill_value=0,
+    )
+    graph_df = graph_df.fillna(0)
+    graph_df[lineages] = graph_df[lineages].astype(int)
+    value_per_df = (graph_df.div(graph_df.sum(axis=1), axis=0) * 100).round(2)
+    value_per_df = value_per_df.fillna(0)
+    samples_per_week = graph_df.sum(axis=1)
+
+    hover_text = [f"{y}" for y in samples_per_week.values]
+    fig.add_trace(
+        go.Scatter(
+            x=value_per_df.index,
+            y=samples_per_week,
+            hoverinfo="text",
+            hovertemplate="%{text}",
+            mode="lines",
+            name="Number of samples",
+            line_color="#0066cc",
+            line_width=2,
+            text=hover_text,
+        ),
+        secondary_y=True,
+    )
+    for lineage in lineages:
+        hover_text = [
+            (
+                f"<b>{lineage}: {y}%</b><extra></extra>"
+                if y > 0
+                else f"{lineage}: {y}%<extra></extra>"
+            )
+            for y in value_per_df[lineage].values
+        ]
+        fig.add_trace(
+            go.Scatter(
+                x=value_per_df.index,
+                y=value_per_df[lineage],
+                hoverinfo="text",
+                hovertemplate="%{text}",
+                mode="lines",
+                name=lineage,
+                opacity=0.7,
+                stackgroup="variants",
+                text=hover_text,
+            ),
+            secondary_y=False,
+        )
+
+    fig.update_xaxes(title="Collection Date (ISOweeks)")
+    fig.update_yaxes(range=[0, 100], title_text="<b>Lineage % relative", secondary_y=False)
+    fig.update_yaxes(
+        title_text="<b>Number of samples processed</b>", secondary_y=True
+    )
+    fig.update_layout(
+        title_text="Variants over the selected period",
+        autotypenumbers="convert types",
+        barmode="stack",
+        hovermode="x unified",
+        legend_xanchor="center",
+        legend_yanchor="top",
+        legend_orientation="h",
+        legend_x=0.5,
+        legend_y=-0.30,
+        bargap=0,
+        bargroupgap=0,
+        margin_l=10,
+        margin_r=10,
+        margin_b=40,
+        margin_t=40,
+        height=600,
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        xaxis=dict(showline=True, linecolor="black", linewidth=2, mirror=True),
+        yaxis=dict(
+            showline=True,
+            linecolor="black",
+            linewidth=2,
+            mirror=True,
+            ticksuffix=" ",
+        ),
+        yaxis2_tickprefix=" ",
+    )
+    return fig
+
+
+def create_lineages_variations_graphic():
+    data_df = load_variant_graphic_dataframe()
+    if isinstance(data_df, dict) and "ERROR" in data_df:
+        return data_df
+    if data_df.empty:
+        return {"ERROR": "No lineage data available"}
+    return {"OK": True}

--- a/dashboard/utils/var_lineage_variation_over_time_graph.py
+++ b/dashboard/utils/var_lineage_variation_over_time_graph.py
@@ -172,10 +172,10 @@ def build_lineage_variation_figure(df_full, start_date=None, end_date=None):
         )
 
     fig.update_xaxes(title="Collection Date (ISOweeks)")
-    fig.update_yaxes(range=[0, 100], title_text="<b>Lineage % relative", secondary_y=False)
     fig.update_yaxes(
-        title_text="<b>Number of samples processed</b>", secondary_y=True
+        range=[0, 100], title_text="<b>Lineage % relative", secondary_y=False
     )
+    fig.update_yaxes(title_text="<b>Number of samples processed</b>", secondary_y=True)
     fig.update_layout(
         title_text="Variants over the selected period",
         autotypenumbers="convert types",

--- a/dashboard/utils/var_lineages_mutation_table_generation.py
+++ b/dashboard/utils/var_lineages_mutation_table_generation.py
@@ -8,13 +8,11 @@ Mutation table under needle plot
 
 # Generic imports
 import pandas as pd
-from dash import dash_table, dcc, html
-from dash.dependencies import Input, Output
-from django_plotly_dash import DjangoDash
 
 # Local imports
 import core.models
 import core.utils.samples
+import core.utils.variants
 
 """
 import core.utils.handling_variant
@@ -81,50 +79,25 @@ def create_dataframe(sample_list, effect_list):
     return df_pandas
 
 
+def get_default_sample_and_effect_options():
+    chromosome_obj = core.utils.variants.get_default_chromosome()
+    if chromosome_obj is None:
+        return [], []
+    sample_list = core.utils.variants.get_sample_in_variant_list(chromosome_obj)
+    if not sample_list:
+        return [], []
+    df = create_dataframe(
+        sample_list=sample_list,
+        effect_list=list(core.models.Effect.objects.values_list("effect", flat=True)),
+    )
+    if df.empty:
+        return sample_list, []
+    return sample_list, list(df["EFFECT"].dropna().unique())
+
+
 def create_mutation_table(sample_list, effect_list):
     df = create_dataframe(sample_list=sample_list, effect_list=effect_list)
-    all_effects = list(df["EFFECT"].unique())
-    PAGE_SIZE = 20
-
-    app = DjangoDash("mutationTable")
-
-    app.layout = html.Div(
-        children=[
-            # html.P(id="mutation_table-message"),
-            html.P("Select effects"),
-            dcc.Dropdown(
-                id="mutation_table-effect_dropdown",
-                options=[{"label": i, "value": i} for i in all_effects],
-                clearable=False,
-                multi=True,
-                value=all_effects,
-                style={"width": "400px"},
-                placeholder="Mutation effect",
-            ),
-            html.Br(),
-            dash_table.DataTable(
-                id="mutation_datatable",
-                data=df.to_dict("records"),
-                columns=[{"name": i, "id": i} for i in df.columns],
-                page_current=0,
-                page_size=PAGE_SIZE,
-                page_action="custom",
-            ),
-        ]
-    )
-
-    @app.callback(
-        Output("mutation_datatable", "data"),
-        Input("mutation_table-effect_dropdown", "value"),
-    )
-    def update_selected_effects(selected_effects):
-        data = {}
-        sample_list = [2018185, 210067]
-
-        if isinstance(selected_effects, list) and len(selected_effects) >= 1:
-            df = create_dataframe(sample_list=sample_list, effect_list=selected_effects)
-            data = df.to_dict("records")
-        return data
+    return df.to_dict("records")
 
     """
     @app.callback(

--- a/dashboard/utils/var_needle_mutation_graph_by_lineage.py
+++ b/dashboard/utils/var_needle_mutation_graph_by_lineage.py
@@ -51,7 +51,9 @@ def build_needle_plot_initial_arguments(lineage_list, lineage):
     }
 
 
-def build_needle_plot_figure(selected_lineage, toggle_rangeslider=None, relayout_data=None):
+def build_needle_plot_figure(
+    selected_lineage, toggle_rangeslider=None, relayout_data=None
+):
     mdata, _, n_samples = get_variant_data_from_lineages(
         graphic_name="variations_per_lineage",
         lineage=selected_lineage,
@@ -116,11 +118,17 @@ def build_needle_plot_figure(selected_lineage, toggle_rangeslider=None, relayout
     domain_selectors = [
         dict(label="All", method="relayout", args=[{"xaxis.range": [0, all_max_x]}])
     ]
-    sorted_domains = sorted(mdata["domains"], key=lambda x: int(x["coord"].split("-")[0]))
+    sorted_domains = sorted(
+        mdata["domains"], key=lambda x: int(x["coord"].split("-")[0])
+    )
     for domain in sorted_domains:
         start, end = map(int, domain["coord"].split("-"))
         domain_selectors.append(
-            dict(label=domain["name"], method="relayout", args=[{"xaxis.range": [start, end]}])
+            dict(
+                label=domain["name"],
+                method="relayout",
+                args=[{"xaxis.range": [start, end]}],
+            )
         )
         max_pos = max(max_pos, end)
         fig.add_shape(
@@ -241,7 +249,9 @@ def build_needle_plot_figure(selected_lineage, toggle_rangeslider=None, relayout
     return fig, markdown_text
 
 
-def create_needle_plot_graph_mutation_by_lineage(lineage_list, lineage, mdata, n_samples):
+def create_needle_plot_graph_mutation_by_lineage(
+    lineage_list, lineage, mdata, n_samples
+):
     if not mdata:
         return {"ERROR": "No lineage mutation data available"}
     return build_needle_plot_initial_arguments(lineage_list, lineage)

--- a/dashboard/utils/var_needle_mutation_graph_by_lineage.py
+++ b/dashboard/utils/var_needle_mutation_graph_by_lineage.py
@@ -1,21 +1,18 @@
 # Generic imports
-import time
 import plotly.graph_objects as go
-import dash
-from dash import dcc, html
-from dash.dependencies import Input, Output, State
-from django_plotly_dash import DjangoDash
 
 # Local imports
 import dashboard.utils.generic_graphic_data
 import dashboard.utils.generic_process_data
 
 
+APP_NAME = "needlePlotMutationByLineage"
+
+
 def get_variant_data_from_lineages(graphic_name=None, lineage=None, chromosome=None):
     json_data = dashboard.utils.generic_graphic_data.get_graphic_json_data(graphic_name)
 
     if json_data is None:
-        # Execute the pre-processed task to get the data
         result = dashboard.utils.generic_process_data.pre_proc_variations_per_lineage(
             chromosome
         )
@@ -23,7 +20,6 @@ def get_variant_data_from_lineages(graphic_name=None, lineage=None, chromosome=N
             return result
 
     json_data = dashboard.utils.generic_graphic_data.get_graphic_json_data(graphic_name)
-    # Return None to indicate that there is no data stored yet
     if json_data is None:
         return None, None, None
 
@@ -34,348 +30,218 @@ def get_variant_data_from_lineages(graphic_name=None, lineage=None, chromosome=N
     return mdata, lineage, n_samples
 
 
-def create_needle_plot_graph_mutation_by_lineage(
-    lineage_list, lineage, mdata, n_samples
-):
-    options = []
-    for lin in lineage_list:
-        options.append({"label": lin, "value": lin})
+def empty_needle_plot_figure():
+    fig = go.Figure()
+    fig.update_layout(
+        title={"text": "Needle Plot", "x": 0.1, "xanchor": "left"},
+        xaxis_title="Genome Position",
+        yaxis_title="Population Allele Frequency",
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        yaxis_range=[-0.12, 1.15],
+    )
+    return fig
 
+
+def build_needle_plot_initial_arguments(lineage_list, lineage):
+    options = [{"label": lin, "value": lin} for lin in lineage_list]
+    return {
+        "needleplot-select-lineage": {"options": options, "value": lineage},
+        "toggle-rangeslider": {"value": ["on"]},
+    }
+
+
+def build_needle_plot_figure(selected_lineage, toggle_rangeslider=None, relayout_data=None):
+    mdata, _, n_samples = get_variant_data_from_lineages(
+        graphic_name="variations_per_lineage",
+        lineage=selected_lineage,
+        chromosome=None,
+    )
+    if not mdata or not mdata.get("x"):
+        return empty_needle_plot_figure(), "No lineage mutations available"
+
+    mdata = dict(mdata)
     mdata["x"] = [int(x) for x in mdata["x"]]
-    app = DjangoDash("needlePlotMutationByLineage", serve_locally=True)
-    app.layout = html.Div(
-        children=[
-            html.Div(
-                children=[
-                    html.Div(
-                        children=[
-                            "Select Lineage",
-                            dcc.Dropdown(
-                                id="needleplot-select-lineage",
-                                options=options,
-                                clearable=False,
-                                multi=False,
-                                value=lineage,
-                                style={"width": "150px", "margin-right": "30px"},
-                            ),
-                        ],
-                        style={"margin-left": "20px"},
-                    ),
-                    html.Div(
-                        [
-                            "Show Range Slider",
-                            dcc.Checklist(
-                                id="toggle-rangeslider",
-                                options=[{"label": "Enable", "value": "on"}],
-                                value=["on"],
-                                inline=True,
-                            ),
-                        ],
-                        style={"margin-left": "20px"},
-                    ),
-                    html.Div(
-                        children=[
-                            dcc.Markdown(
-                                id="samples_markdown",
-                                children=f"Showing mutations for {n_samples} samples",
-                            )
-                        ],
-                        style={"margin-left": "50px"},
-                    ),
-                ],
-                style={
-                    "display": "flex",
-                    "justify-content": "start",
-                    "align-items": "flex-start",
-                },
-            ),
-            html.Div(
-                children=[
-                    dcc.Loading(
-                        id="loading_plot_wrapper",
-                        type="default",
-                        children=[
-                            html.Div(
-                                id="needleplot-container-div",
-                                children=[
-                                    dcc.Graph(
-                                        id="needleplot-graph",
-                                        style={"padding-top": "15px"},
-                                    ),
-                                    dcc.Store(
-                                        id="debounced-relayout", storage_type="memory"
-                                    ),
-                                    dcc.Store(
-                                        id="relayout-timestamp", storage_type="memory"
-                                    ),
-                                ],
-                                style={"position": "relative"},
-                            )
-                        ],
-                        overlay_style={"visibility": "visible", "filter": "blur(1px)"},
-                        parent_style={"position": "relative"},
-                    ),
-                    dcc.Store(
-                        id="previous-data",
-                        storage_type="memory",
-                        data={"first_load": True},
-                    ),
-                ],
-            ),
-        ]
-    )
+    markdown_text = f"Showing mutations for {n_samples} samples"
+    domain_color_map = {
+        "orf1ab": "#1f77b4",
+        "S": "#ff7f0e",
+        "ORF3a": "#2ca02c",
+        "E": "#d62728",
+        "M": "#9467bd",
+        "ORF6": "#8c564b",
+        "ORF7a": "#e377c2",
+        "ORF7b": "#7f7f7f",
+        "ORF8": "#bcbd22",
+        "N": "#17becf",
+        "ORF10": "#ffbb78",
+    }
+    mutation_color_map = {
+        "missense_variant": "#E6194B",
+        "Unknown": "#A9A9A9",
+        "disruptive_inframe_insertion": "#BFEF45",
+        "frameshift_variant": "#F58231",
+        "splice_region_variant&stop_retained_variant": "#FF8DA1",
+        "conservative_inframe_deletion": "#BF8970",
+        "synonymous_variant": "#4363D8",
+        "stop_lost": "#42D4F4",
+        "frameshift_variant&start_lost": "#F032E6",
+        "start_lost": "#3CB44B",
+        "disruptive_inframe_deletion": "#D4AF37",
+        "gene_fusion": "#469990",
+        "conservative_inframe_insertion": "#DCBEFF",
+        "stop_gained": "#9A6324",
+        "upstream_gene_variant": "#911EB4",
+        "frameshift_variant&stop_lost&splice_region_variant": "#800000",
+        "frameshift_variant&stop_gained": "#A65628",
+        "stop_retained_variant": "#FF6347",
+        "downstream_gene_variant": "#808000",
+    }
 
-    @app.callback(
-        Output("relayout-timestamp", "data"),
-        Output("debounced-relayout", "data"),
-        Input("needleplot-graph", "relayoutData"),
-        State("relayout-timestamp", "data"),
-        prevent_initial_call=True,
-    )
-    def debounce_relayout(relayout_data, last_timestamp):
-        now = time.time()
-        if last_timestamp is None or now - last_timestamp > 0.4:
-            return now, relayout_data
-        raise dash.exceptions.PreventUpdate
-
-    @app.callback(
-        Output("needleplot-graph", "figure"),
-        Output("samples_markdown", "children"),
-        Input("debounced-relayout", "data"),
-        Input("needleplot-select-lineage", "value"),
-        Input("toggle-rangeslider", "value"),
-        prevent_initial_call=True,
-    )
-    def update_sample(relayout_data, selected_lineage, toogle_rangeslider):
-        mdata, _, n_samples = get_variant_data_from_lineages(
-            graphic_name="variations_per_lineage",
-            lineage=selected_lineage,
-            chromosome=None,
+    fig = go.Figure()
+    if toggle_rangeslider == ["on"]:
+        fig.update_layout(
+            xaxis_rangeslider=dict(visible=True, bgcolor="rgba(255, 255, 255, 0)")
         )
-        mdata["x"] = [int(x) for x in mdata["x"]]
-        markdown_text = f"Showing mutations for {n_samples} samples"
-        # TODO: Include all color mapping dicts for domains and mutation types in graphic_json
-        domain_color_map = {
-            "orf1ab": "#1f77b4",  # Blue
-            "S": "#ff7f0e",  # Orange
-            "ORF3a": "#2ca02c",  # Green
-            "E": "#d62728",  # Red
-            "M": "#9467bd",  # Purple
-            "ORF6": "#8c564b",  # Brown
-            "ORF7a": "#e377c2",  # Pink
-            "ORF7b": "#7f7f7f",  # Gray
-            "ORF8": "#bcbd22",  # Yellow-green
-            "N": "#17becf",  # Cyan
-            "ORF10": "#ffbb78",  # Light orange
-        }
-        mutation_color_map = {
-            "missense_variant": "#E6194B",  # Red
-            "Unknown": "#A9A9A9",  # Gray THESE ARE RENAMED FROM NONE VALUES
-            "disruptive_inframe_insertion": "#BFEF45",  # Light Green
-            "frameshift_variant": "#F58231",  # Orange
-            "splice_region_variant&stop_retained_variant": "#FF8DA1",  # Pink
-            "conservative_inframe_deletion": "#BF8970",  # Yellow
-            "synonymous_variant": "#4363D8",  # Blue
-            "stop_lost": "#42D4F4",  # Cyan
-            "frameshift_variant&start_lost": "#F032E6",  # Magenta
-            "start_lost": "#3CB44B",  # Green
-            "disruptive_inframe_deletion": "#D4AF37",  # Light Red
-            "gene_fusion": "#469990",  # Teal
-            "conservative_inframe_insertion": "#DCBEFF",  # Lavender
-            "stop_gained": "#9A6324",  # Brown
-            "upstream_gene_variant": "#911EB4",  # Purple
-            "frameshift_variant&stop_lost&splice_region_variant": "#800000",  # Dark Red
-            "frameshift_variant&stop_gained": "#A65628",  # Dark Brown
-            "stop_retained_variant": "#FF6347",  # Tomato Red
-            "downstream_gene_variant": "#808000",  # Olive
-        }
+    if relayout_data and "xaxis.range" in relayout_data:
+        min_x, max_x = relayout_data["xaxis.range"]
+        fig.update_layout(xaxis=dict(range=relayout_data["xaxis.range"]))
+    else:
+        min_x, max_x = (min(mdata["x"]), max(mdata["x"]))
 
-        # Create NeedlePlot and extract figure
-        fig = go.Figure()
-        if toogle_rangeslider == ["on"]:
-            fig.update_layout(
-                xaxis_rangeslider=dict(visible=True, bgcolor="rgba(255, 255, 255, 0)")
-            )
-        if relayout_data and "xaxis.range" in relayout_data:
-            # relayout data listens to updates in the plot from rangeslider
-            min_x, max_x = relayout_data["xaxis.range"]
-            fig.update_layout(xaxis=dict(range=relayout_data["xaxis.range"]))
-        else:
-            min_x, max_x = (min(mdata["x"]), max(mdata["x"]))
-
-        # X range will be used to define wether to show genome annotations
-        x_range = max_x - min_x
-
-        max_pos = 0
-        # Store used annotation possitions to avoid overlap
-        used_annotations = []
-        all_max_x = max([int(x["coord"].split("-")[1]) for x in mdata["domains"]])
-        domain_selectors = [
-            dict(
-                label="All",
-                method="relayout",
-                args=[{"xaxis.range": [0, all_max_x]}],
-            )
-        ]
-        # Sort domains based on their starting positions, needed for annotations
-        sorted_domains = sorted(
-            mdata["domains"], key=lambda x: int(x["coord"].split("-")[0])
+    x_range = max_x - min_x if max_x > min_x else 1
+    max_pos = 0
+    used_annotations = []
+    all_max_x = max([int(x["coord"].split("-")[1]) for x in mdata["domains"]])
+    domain_selectors = [
+        dict(label="All", method="relayout", args=[{"xaxis.range": [0, all_max_x]}])
+    ]
+    sorted_domains = sorted(mdata["domains"], key=lambda x: int(x["coord"].split("-")[0]))
+    for domain in sorted_domains:
+        start, end = map(int, domain["coord"].split("-"))
+        domain_selectors.append(
+            dict(label=domain["name"], method="relayout", args=[{"xaxis.range": [start, end]}])
         )
-        for domain in sorted_domains:
-            start, end = map(int, domain["coord"].split("-"))
-            domain_selectors.append(
-                dict(
-                    label=domain["name"],
-                    method="relayout",
-                    args=[
-                        {
-                            "xaxis.range": [start, end],
-                        }
-                    ],
-                )
-            )
-            max_pos = max(max_pos, end)
-            fig.add_shape(
-                type="rect",
-                x0=start,
-                x1=end,
-                y0=0,
-                y1=-0.12,
-                fillcolor=domain_color_map.get(domain["name"], "lightgray"),
-                opacity=0.3,
-                layer="below",
-                line=dict(width=0),
-            )
-            # Define a threshold for spacing relative to the x range. I used 0.04 ad-hoc
-            x_space_threshold = x_range * 0.05
-
-            # Determine an appropriate y-level to avoid overlap
-            annotation_x = (start + end) / 2  # Place annotation in the middle
-            annotation_y = -0.06  # Default y-level
-
-            for prev_x, _ in used_annotations:
-                if abs(annotation_x - prev_x) < x_space_threshold:
-                    domain["name"] = ""  # Do not show annotation if it would overlap
-                    break
-            else:
-                # Store the adjusted position if the annotation is used
-                used_annotations.append((annotation_x, annotation_y))
-
-            # Add text labels for domains
-            fig.add_annotation(
-                x=annotation_x,
-                y=annotation_y,
-                text=domain["name"],
-                showarrow=False,
-                font=dict(size=12, color="black"),
-            )
+        max_pos = max(max_pos, end)
         fig.add_shape(
             type="rect",
-            x0=0,
-            x1=max_pos,
+            x0=start,
+            x1=end,
             y0=0,
             y1=-0.12,
-            fillcolor="lightgray",
+            fillcolor=domain_color_map.get(domain["name"], "lightgray"),
             opacity=0.3,
             layer="below",
             line=dict(width=0),
         )
-        # Filter mutations based on selected range
-        filtered_indices = [i for i, x in enumerate(mdata["x"]) if min_x <= x <= max_x]
-
-        filtered_x = [mdata["x"][i] for i in filtered_indices]
-        filtered_y = [mdata["y"][i] for i in filtered_indices]
-        filtered_mutation_groups = [
-            mdata["mutationGroups"][i] for i in filtered_indices
-        ]
-
-        mutation_traces = {}
-        for x, y, mutation_type in zip(
-            filtered_x, filtered_y, filtered_mutation_groups
-        ):
-            if mutation_type is None:
-                mutation_type = "Unknown"
-            color = mutation_color_map.get(mutation_type)
-
-            if mutation_type not in mutation_traces:
-                mutation_traces[mutation_type] = {
-                    "x_points": [],
-                    "y_points": [],
-                    "x_lines": [],
-                    "y_lines": [],
-                    "color": color,
-                }
-
-            # Add mutation marker
-            mutation_traces[mutation_type]["x_points"].append(int(x))
-            mutation_traces[mutation_type]["y_points"].append(y)
-
-            # Ensure each line (needle) is positioned at its own location
-            mutation_traces[mutation_type]["x_lines"].extend(
-                [int(x), int(x), None]
-            )  # None for breaks
-            mutation_traces[mutation_type]["y_lines"].extend(
-                [-0.005, y, None]
-            )  # None for breaks
-
-        # Add traces for each mutation type
-        for mutation_type, data in mutation_traces.items():
-            # Line trace for needles
-            fig.add_trace(
-                go.Scatter(
-                    x=data["x_lines"],
-                    y=data["y_lines"],
-                    mode="lines",
-                    line=dict(color=data["color"], width=1),
-                    name=mutation_type,  # Legend entry (same as marker)
-                    legendgroup=mutation_type,  # group legend with markers
-                    showlegend=False,  # Hide extra legend entry for lines
-                )
-            )
-
-            # Marker trace for mutation points
-            fig.add_trace(
-                go.Scatter(
-                    x=data["x_points"],
-                    y=data["y_points"],
-                    mode="markers",
-                    marker=dict(size=10, color=data["color"]),
-                    legendgroup=mutation_type,  # Group legend with lines
-                    name=mutation_type,  # Legend entry
-                )
-            )
-        fig.update_layout(
-            title={
-                "text": "Needle Plot",
-                "x": 0.1,
-                "xanchor": "left",
-            },
-            xaxis=dict(
-                title="Genome Position",
-                tickmode="auto",
-                automargin=True,
-                tickformat="d",
-                showgrid=False,
-                zeroline=False,
-                range=[min_x, max_x],
-                rangeselector=dict(),
-            ),
-            paper_bgcolor="white",
-            plot_bgcolor="white",
-            yaxis_title="Population Allele Frequency",
-            yaxis_range=[-0.12, 1.15],
-            updatemenus=[
-                dict(
-                    type="buttons",
-                    direction="right",
-                    x=0,
-                    y=1.15,
-                    xanchor="left",
-                    showactive=True,
-                    buttons=domain_selectors,
-                )
-            ],
+        x_space_threshold = x_range * 0.05
+        annotation_x = (start + end) / 2
+        annotation_y = -0.06
+        for prev_x, _ in used_annotations:
+            if abs(annotation_x - prev_x) < x_space_threshold:
+                domain["name"] = ""
+                break
+        else:
+            used_annotations.append((annotation_x, annotation_y))
+        fig.add_annotation(
+            x=annotation_x,
+            y=annotation_y,
+            text=domain["name"],
+            showarrow=False,
+            font=dict(size=12, color="black"),
         )
-        return fig, markdown_text
+    fig.add_shape(
+        type="rect",
+        x0=0,
+        x1=max_pos,
+        y0=0,
+        y1=-0.12,
+        fillcolor="lightgray",
+        opacity=0.3,
+        layer="below",
+        line=dict(width=0),
+    )
 
-    return app
+    filtered_indices = [i for i, x in enumerate(mdata["x"]) if min_x <= x <= max_x]
+    filtered_x = [mdata["x"][i] for i in filtered_indices]
+    filtered_y = [mdata["y"][i] for i in filtered_indices]
+    filtered_mutation_groups = [mdata["mutationGroups"][i] for i in filtered_indices]
+
+    mutation_traces = {}
+    for x, y, mutation_type in zip(filtered_x, filtered_y, filtered_mutation_groups):
+        if mutation_type is None:
+            mutation_type = "Unknown"
+        color = mutation_color_map.get(mutation_type, "#6c757d")
+
+        if mutation_type not in mutation_traces:
+            mutation_traces[mutation_type] = {
+                "x_points": [],
+                "y_points": [],
+                "x_lines": [],
+                "y_lines": [],
+                "color": color,
+            }
+
+        mutation_traces[mutation_type]["x_points"].append(int(x))
+        mutation_traces[mutation_type]["y_points"].append(y)
+        mutation_traces[mutation_type]["x_lines"].extend([int(x), int(x), None])
+        mutation_traces[mutation_type]["y_lines"].extend([-0.005, y, None])
+
+    for mutation_type, data in mutation_traces.items():
+        fig.add_trace(
+            go.Scatter(
+                x=data["x_lines"],
+                y=data["y_lines"],
+                mode="lines",
+                line=dict(color=data["color"], width=1),
+                name=mutation_type,
+                legendgroup=mutation_type,
+                showlegend=False,
+            )
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=data["x_points"],
+                y=data["y_points"],
+                mode="markers",
+                marker=dict(size=10, color=data["color"]),
+                legendgroup=mutation_type,
+                name=mutation_type,
+            )
+        )
+
+    fig.update_layout(
+        title={"text": "Needle Plot", "x": 0.1, "xanchor": "left"},
+        xaxis=dict(
+            title="Genome Position",
+            tickmode="auto",
+            automargin=True,
+            tickformat="d",
+            showgrid=False,
+            zeroline=False,
+            range=[min_x, max_x],
+            rangeselector=dict(),
+        ),
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        yaxis_title="Population Allele Frequency",
+        yaxis_range=[-0.12, 1.15],
+        updatemenus=[
+            dict(
+                type="buttons",
+                direction="right",
+                x=0,
+                y=1.15,
+                xanchor="left",
+                showactive=True,
+                buttons=domain_selectors,
+            )
+        ],
+    )
+    return fig, markdown_text
+
+
+def create_needle_plot_graph_mutation_by_lineage(lineage_list, lineage, mdata, n_samples):
+    if not mdata:
+        return {"ERROR": "No lineage mutation data available"}
+    return build_needle_plot_initial_arguments(lineage_list, lineage)

--- a/dashboard/utils/var_needle_mutation_graph_by_lineage.py
+++ b/dashboard/utils/var_needle_mutation_graph_by_lineage.py
@@ -5,7 +5,6 @@ import plotly.graph_objects as go
 import dashboard.utils.generic_graphic_data
 import dashboard.utils.generic_process_data
 
-
 APP_NAME = "needlePlotMutationByLineage"
 
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -156,9 +156,6 @@ def variants_mutations_in_lineages_heatmap(request):
             "dashboard/variantsMutationsInLineagesHeatmap.html",
             {"ERROR": core.config.ERROR_VARIANT_IN_SAMPLE_NOT_DEFINED},
         )
-    dashboard.utils.var_heatmap_mutation_graph_by_lineage.create_heatmap(
-        sample_list, gene_list
-    )
     return render(request, "dashboard/variantsMutationsInLineagesHeatmap.html")
 
 

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -44,12 +44,19 @@ def mutations_in_lineage(request):
             "dashboard/variantMutationsInLineage.html",
             {"ERROR": dashboard.dashboard_config.ERROR_NO_LINEAGES_ARE_DEFINED_YET},
         )
-    dashboard.utils.var_needle_mutation_graph_by_lineage.create_needle_plot_graph_mutation_by_lineage(
+    initial_arguments = dashboard.utils.var_needle_mutation_graph_by_lineage.create_needle_plot_graph_mutation_by_lineage(
         lineages_list, lineage, mdata, n_samples
     )
+    if "ERROR" in initial_arguments:
+        return render(
+            request,
+            "dashboard/variantMutationsInLineage.html",
+            {"ERROR": initial_arguments["ERROR"]},
+        )
     return render(
         request,
         "dashboard/variantMutationsInLineage.html",
+        {"needle_plot_initial_arguments": initial_arguments},
     )
 
 


### PR DESCRIPTION
## PR Description

This PR fixes several intermittent failures in the platform Dash graphs.

### Problems found

We were hitting two structural issues in the current `django-plotly-dash` integration:

1. Several Dash apps were being created during request handling instead of being registered once at Django startup.
2. Dash `initial_arguments` were configured to use cache storage, but the current deployment uses `LocMemCache`, which is process-local and not shared across workers.

Because of this, the page request and the embedded Dash iframe requests could be handled by different workers with different in-memory state. In practice, this caused inconsistent behavior such as:

- graphs loading empty even when data existed
- fallback messages like "No variants available for the selected sample"
- intermittent failures in embedded Dash routes
- inconsistent behavior after reinstall/redeploy

### Changes applied

To solve this, the PR introduces the following changes:

- register the affected Dash apps once at startup through `AppConfig.ready()`
- stop creating Dash apps dynamically inside views and request-time helper functions
- pass per-view graph state explicitly through `initial_arguments`
- store Dash `initial_arguments` in the Django session instead of process-local cache
- keep the current Dash-based UI approach without replacing these graphs with plain Plotly/JS

### Affected graphs

The stabilization was applied to:

- `samplePerLabGraphic`
- `samplesReceivedOverTimeMap`
- `sampleVariantGraphic`
- `variationLineageOverTime`
- `needlePlotMutationByLineage`

These changes make the graph state deterministic across requests and remove the worker-local state issues that were causing the inconsistent rendering.