### PR TITLE
Fix Dash static component collection in deployment

### DIFF
--- a/conf/template_settings.py
+++ b/conf/template_settings.py
@@ -139,7 +139,6 @@ STATICFILES_FINDERS = [
 
 PLOTLY_COMPONENTS = [
     "dpd_components",
-    "dpd_static_support",
     "dash_bootstrap_components",
     "dash_daq",
     "dash_bio",


### PR DESCRIPTION
## PR Description

This PR fixes Dash static asset collection during deployment.

### Problem

The current Dash configuration includes `dpd_static_support` in `PLOTLY_COMPONENTS`, but that module is not installed in the deployment environment.

Because of that:

- `collectstatic` fails while loading Django static finders
- Dash component bundles are not collected into `/static/dash/component/...`
- some Dash apps load their backend routes correctly but render blank in the browser due to missing JS assets
