### PR TITLE
Make variants and methodology dashboards accessible without login and reduce methodology payload

### DIFF
--- a/conf/template_settings.py
+++ b/conf/template_settings.py
@@ -145,7 +145,7 @@ PLOTLY_COMPONENTS = [
 ]
 
 PLOTLY_DASH = {
-    "view_decorator": "django_plotly_dash.access.login_required",
+    "view_decorator": "core.dash_access.selective_login_required",
     # Use the Django session backend for initial_arguments. The default cache is
     # LocMemCache in this deployment, which is process-local and breaks Dash
     # iframe initial state across multiple workers.

--- a/core/dash_access.py
+++ b/core/dash_access.py
@@ -1,0 +1,27 @@
+from functools import wraps
+
+from django.contrib.auth.decorators import login_required as login_required_decorator
+
+
+# Only Dash apps embedded in intranet-only pages should require authentication.
+# Public dashboard apps must stay accessible without login.
+PROTECTED_DASH_APPS = {
+    "samplePerLabGraphic",
+    "sampleVariantGraphic",
+    "samplesReceivedOverTimeMap",
+}
+
+
+def selective_login_required(view_function, **kwargs):
+    @wraps(view_function)
+    def wrapped_view(request, *args, **view_kwargs):
+        ident = view_kwargs.get("ident")
+        if ident in PROTECTED_DASH_APPS:
+            protected_view = login_required_decorator(view_function)
+            return protected_view(request, *args, **view_kwargs)
+        return view_function(request, *args, **view_kwargs)
+
+    if getattr(view_function, "csrf_exempt", False):
+        wrapped_view.csrf_exempt = True
+
+    return wrapped_view

--- a/core/dash_access.py
+++ b/core/dash_access.py
@@ -2,7 +2,6 @@ from functools import wraps
 
 from django.contrib.auth.decorators import login_required as login_required_decorator
 
-
 # Only Dash apps embedded in intranet-only pages should require authentication.
 # Public dashboard apps must stay accessible without login.
 PROTECTED_DASH_APPS = {

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -80,6 +80,7 @@
         {% block extra_css %}{% endblock %}
         <!--   Jquery scripts   -->
         <script src="{% static 'core/vendor/jquery/js/jquery.min.js' %}"></script>
+        <script src="{% static 'dash/component/plotly/package_data/plotly.min.js' %}"></script>
         <link href="{% static 'docs/css/docs.css' %}" rel="stylesheet">
     </head>
     <!-- <body style="background-color: white!important;"> -->

--- a/dashboard/utils/plotly.py
+++ b/dashboard/utils/plotly.py
@@ -28,6 +28,10 @@ COLOR_PALETTE = [
     "#46523a",
 ]
 
+PLOTLY_CONFIG = {
+    "displaylogo": False,
+}
+
 DEFAULT_MARGIN = dict(t=30, b=120, l=50, r=20)
 DEFAULT_HEIGHT = 400
 DEFAULT_XAXIS = dict(tickangle=-45, automargin=False)
@@ -194,7 +198,12 @@ def bar_graphic(data, col_names, legend, yaxis, options):
     )
     if wrap_length or truncate_length:
         fig.update_xaxes(ticktext=formatted_labels)
-    plot_div = plot(fig, output_type="div", config={"displaylogo": False})
+    plot_div = plot(
+        fig,
+        output_type="div",
+        include_plotlyjs=False,
+        config=PLOTLY_CONFIG,
+    )
     return plot_div
 
 
@@ -222,7 +231,12 @@ def line_graphic(x_data, y_data, options):
         height=DEFAULT_HEIGHT,
         xaxis=DEFAULT_XAXIS,
     )
-    plot_div = plot(fig, output_type="div", config={"displaylogo": False})
+    plot_div = plot(
+        fig,
+        output_type="div",
+        include_plotlyjs=False,
+        config=PLOTLY_CONFIG,
+    )
     return plot_div
 
 
@@ -245,7 +259,12 @@ def pie_graphic(labels, values, options, show_legend=True):
         template=mi_template,
         title=options["title"],
     )
-    plot_div = plot(fig, output_type="div", config={"displaylogo": False})
+    plot_div = plot(
+        fig,
+        output_type="div",
+        include_plotlyjs=False,
+        config=PLOTLY_CONFIG,
+    )
     return plot_div
 
 
@@ -318,7 +337,12 @@ def box_plot_graphic(data, options):
         xaxis=DEFAULT_XAXIS,
         title=options["title"],
     )
-    plot_div = plot(fig, output_type="div", config={"displaylogo": False})
+    plot_div = plot(
+        fig,
+        output_type="div",
+        include_plotlyjs=False,
+        config=PLOTLY_CONFIG,
+    )
     return plot_div
 
 
@@ -350,7 +374,12 @@ def ridge_plot_graphic(data, options):
         yaxis_title="",
         showlegend=False,
     )
-    plot_div = plot(fig, output_type="div", config={"displaylogo": False})
+    plot_div = plot(
+        fig,
+        output_type="div",
+        include_plotlyjs=False,
+        config=PLOTLY_CONFIG,
+    )
     return plot_div
 
 
@@ -390,5 +419,10 @@ def box_plot_graphic_bins(x_data, y_data, options):
         height=DEFAULT_HEIGHT,
         xaxis=DEFAULT_XAXIS,
     )
-    plot_div = plot(fig, output_type="div", config={"displaylogo": False})
+    plot_div = plot(
+        fig,
+        output_type="div",
+        include_plotlyjs=False,
+        config=PLOTLY_CONFIG,
+    )
     return plot_div

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -21,13 +21,9 @@ import dashboard.utils.var_needle_mutation_graph_by_lineage
 import dashboard.utils.var_samples_received_over_time_pie
 
 
-# dashboard/variants
-@login_required
 def variants_index(request):
     return render(request, "dashboard/variantsIndex.html")
 
-
-@login_required
 def mutations_in_lineage(request):
     # mutations in lineages by lineage
     def_chrom = core.utils.variants.get_default_chromosome()
@@ -62,7 +58,6 @@ def mutations_in_lineage(request):
 
 # FIXME: template html has bad ref in plotly_app. App name shoudl be replaced by 'model3D_bn'
 # FIXME: Couldn't find in variants dashboard a button or ref to acces this url
-@login_required
 def spike_mutations_3d(request):
     dashboard.utils.var_molecule3D_bn_graph.create_model3D_bn()
     return render(request, "dashboard/variantSpikeMutations3D.html")
@@ -119,7 +114,6 @@ def samples_received_over_time_pie_laboratory(request):
 
 
 # FIXME: isn't called from urls.py and html template is not available.
-@login_required
 def variants_mutations_in_lineages_heatmap(request):
     chromesome_objs = core.utils.variants.get_all_chromosome_objs()
     if chromesome_objs is None:
@@ -159,14 +153,11 @@ def variants_mutations_in_lineages_heatmap(request):
     return render(request, "dashboard/variantsMutationsInLineagesHeatmap.html")
 
 
-# dashboard/methodology
-@login_required
 def methodology_index(request):
     graphics = dashboard.utils.met_index.index_dash_fields()
     return render(request, "dashboard/methodologyIndex.html", {"graphics": graphics})
 
 
-@login_required
 def methodology_host_info(request):
     host_info = dashboard.utils.met_host_info.host_info_graphics()
     if "ERROR" in host_info:
@@ -178,7 +169,6 @@ def methodology_host_info(request):
     )
 
 
-@login_required
 def methodology_sequencing(request):
     sequencing = dashboard.utils.met_sequencing.sequencing_graphics()
     if "ERROR" in sequencing:
@@ -194,7 +184,6 @@ def methodology_sequencing(request):
     )
 
 
-@login_required
 def methodology_sample_processing(request):
     sample_processing = (
         dashboard.utils.met_sample_preprocessing.sample_processing_graphics()
@@ -212,7 +201,6 @@ def methodology_sample_processing(request):
     )
 
 
-@login_required
 def methodology_bioinfo(request):
     bioinfo = dashboard.utils.met_bioinfo.bioinfo_graphics()
     return render(request, "dashboard/methodologyBioinfo.html", {"bioinfo": bioinfo})

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -24,6 +24,7 @@ import dashboard.utils.var_samples_received_over_time_pie
 def variants_index(request):
     return render(request, "dashboard/variantsIndex.html")
 
+
 def mutations_in_lineage(request):
     # mutations in lineages by lineage
     def_chrom = core.utils.variants.get_default_chromosome()


### PR DESCRIPTION
## PR Description

This PR fixes access control for the public dashboard section and reduces the payload size of the Methodology pages.

### Problems

`Variants` and `Methodology` should be accessible without authentication, but they were requiring login.

This happened because authentication was being enforced both in the dashboard views and in the Dash routing layer, which made public dashboard pages behave like intranet-only pages.

In addition, Methodology pages were returning very large HTML responses because each Plotly chart was embedding its own Plotly JS bundle. This made pages such as `Sequencing Overview` and `Sample Processing` unnecessarily heavy and slow to load.