### PR TITLE
included new strategy for installation so images are install complete and some fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,9 +56,11 @@ ARG INSTALL_TYPE=dep
 ARG GIT_REVISION=main
 ARG INSTALL_CONF=conf/docker_test_settings.txt
 
-# Execute the dependency stage only; app migrations run when the container is up.
+# Prepare dependencies and stage the application tree in the image so the
+# container can restart without rerunning install-time file generation.
 ENV SKIP_SYSTEM_PACKAGES=1
 RUN /bin/bash install.sh --install dep --git_revision $GIT_REVISION --conf $INSTALL_CONF --skip_apache_restart
+RUN /bin/bash install.sh --stage install --git_revision $GIT_REVISION --conf $INSTALL_CONF --skip_apache_restart
 # Use the virtualenv created by install.sh
 ENV PATH="${APP_INSTALL_PATH}/virtualenv/bin:${PATH}"
 

--- a/LEAME.md
+++ b/LEAME.md
@@ -233,6 +233,8 @@ LOG_PATH='/var/log/apps/relecov-iskylims'  # obligatorio si LOG_TYPE='symbolic_l
 
 > Ejecuta los comandos desde la carpeta del proyecto correspondiente y con `install_settings.txt` ya configurado.
 
+La separación interna entre preparación de ficheros y bootstrap se usa ahora para las imágenes de contenedor. En bare-metal no cambian los comandos operativos: `--install` y `--upgrade` siguen ejecutando el flujo completo de dependencias, aplicación y base de datos.
+
 
 ## 6.1 Instalación *relecov-platform*
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RELECOV Platform deployment guide (containers and bare-metal), including iSkyLIM
     - [Local test stack](#local-test-stack)
     - [Production container stack](#production-container-stack)
       - [Persist logs/documents on the host](#persist-logsdocuments-on-the-host)
-      - [Apache reverse proxy (host)](#apache-reverse-proxy-host)
+      - [Apache reverse proxy (container) + Gunicorn](#apache-reverse-proxy-container--gunicorn)
     - [Upgrade docker deployment](#upgrade-docker-deployment)
   - [Bare-metal deployment (Ubuntu/CentOS)](#bare-metal-deployment-ubuntucentos)
     - [Install](#install)
@@ -101,6 +101,8 @@ bash container_install.sh --test --engine podman \
   2>&1 | tee relecov_test_install.log
 ```
 
+The container images now include the staged application trees for both `relecov-platform` and `relecov-iskylims`. Test containers can therefore be recreated or restarted without rerunning the file installation step; `container_install.sh` only runs the runtime bootstrap tasks inside each container.
+
 ### Production container stack
 
 1. Prepare production confs (separate for each service):
@@ -129,11 +131,15 @@ bash container_install.sh --engine podman \
 - iSkyLIMS: `http://<host>:8001`
 - Nextstrain: `http://<host>:8100`
 
+Production images now bake the staged Django application trees into the images themselves. Host reboots or container recreation no longer require rerunning the app installation step; `container_install.sh` only performs runtime bootstrap tasks such as migrations, optional scripts, superuser creation on first install, and `collectstatic`.
+
 #### Persist logs/documents on the host
 
 For production container deployments, keep these paths persistent:
 
 - Logs: `/var/log/local/apps/relecov-platform` -> `/opt/relecov-platform/logs`
+- Apache logs: `/var/log/local/apache` -> `/var/log/httpd`
+- Apache config: `${APP_INSTALL_PATH:-/opt/relecov-platform}/conf/relecov_apache_reverse_proxy.conf` -> `/etc/httpd/conf.d/relecov.conf`
 - Documents: named volume `relecov_documents` -> `/opt/relecov-platform/documents`
 - Static: `/opt/relecov-platform/static-host` -> `/opt/relecov-platform/static`
 
@@ -141,32 +147,19 @@ Prepare host directories and ownership:
 
 ```bash
 sudo mkdir -p /var/log/local/apps/relecov-platform
+sudo mkdir -p /var/log/local/apache
+sudo mkdir -p ${APP_INSTALL_PATH:-/opt/relecov-platform}/conf
 sudo mkdir -p /opt/relecov-platform/static-host
-sudo chown -R ${APP_UID:-1212}:${APP_GID:-1212} /var/log/local/apps/relecov-platform /opt/relecov-platform/static-host
+sudo chown -R ${APP_UID:-1212}:${APP_GID:-1212} /var/log/local/apps/relecov-platform /opt/relecov-platform/static-host ${APP_INSTALL_PATH:-/opt/relecov-platform}
 ```
 
-#### Apache reverse proxy (host)
+#### Apache reverse proxy (container) + Gunicorn
 
-For production, host Apache can proxy the platform container on `localhost:8000`.
+For production, the `app` container runs `gunicorn` and the `apache` service in `docker-compose.prod.yml` acts as the reverse proxy for RELECOV Platform, iSkyLIMS, and Nextstrain.
 
-You can use the existing Apache templates in this repository:
+During `container_install.sh`, the file `conf/relecov_apache_reverse_proxy.conf` is copied to `${APP_INSTALL_PATH:-/opt/relecov-platform}/conf/relecov_apache_reverse_proxy.conf` on the host before `compose up`. Runtime Apache logs are written to `/var/log/local/apache`.
 
-- Ubuntu/Debian: `conf/relecov_apache_ubuntu.conf`
-- CentOS/RHEL: `conf/relecov_apache_centos_redhat.conf`
-
-Copy and enable (adapt paths/domain names to your environment):
-
-```bash
-# Ubuntu/Debian
-sudo cp conf/relecov_apache_ubuntu.conf /etc/apache2/sites-available/relecov-platform.conf
-sudo a2ensite relecov-platform.conf
-sudo a2enmod proxy proxy_http headers rewrite
-sudo systemctl reload apache2
-
-# CentOS/RHEL
-sudo cp conf/relecov_apache_centos_redhat.conf /etc/httpd/conf.d/relecov-platform.conf
-sudo systemctl reload httpd
-```
+If you need a different runtime root, export `APP_INSTALL_PATH` before running `container_install.sh`. The compose file already mounts the Apache config from `${APP_INSTALL_PATH}`.
 
 ### Upgrade docker deployment
 
@@ -181,6 +174,8 @@ bash container_install.sh --engine podman \
   --install_conf_map iskylims_app,../relecov-iskylims/conf/docker_production_iskylims_settings.txt \
   2>&1 | tee relecov_prod_upgrade.log
 ```
+
+The upgrade path rebuilds/restarts the containers and runs `install.sh --bootstrap upgrade` inside each app container. The app files are already baked into the rebuilt images; the bootstrap phase applies migrations with `--fake-initial`, refreshes static files, and skips first-install setup.
 
 ## Bare-metal deployment (Ubuntu/CentOS)
 
@@ -201,6 +196,8 @@ bash install.sh --install full --conf conf/install_settings.txt
 cd ../relecov-iskylims
 bash install.sh --install full --conf conf/install_settings.txt
 ```
+
+The staged/bootstrap split added for container images is internal. Bare-metal commands do not change: `--install` and `--upgrade` still run the complete dependency, application, and database workflow shown here.
 
 ### Upgrade
 

--- a/container_install.sh
+++ b/container_install.sh
@@ -130,6 +130,24 @@ compose_exec() {
     "${COMPOSE_CMD[@]}" "$@"
 }
 
+copy_with_podman_fallback() {
+    local src="$1"
+    local dst="$2"
+
+    if cp "$src" "$dst" 2>/dev/null; then
+        return 0
+    fi
+
+    if [ "$engine" = "podman" ]; then
+        if podman unshare cp "$src" "$dst"; then
+            return 0
+        fi
+    fi
+
+    echo "Failed to copy '$src' to '$dst'" >&2
+    return 1
+}
+
 # PARSE VARIABLE ARGUMENTS WITH getopts
 options=":d:g:c:s:j:a:m:b:f:e:vhntp"
 while getopts $options opt; do
@@ -636,7 +654,7 @@ platform_install_path="$(service_install_path "app")"
 if service_exists "apache"; then
     mkdir -p "$platform_install_path/conf" "$platform_install_path/logs/apache"
     if [ -f "$repo_root/conf/relecov_apache_reverse_proxy.conf" ]; then
-        cp "$repo_root/conf/relecov_apache_reverse_proxy.conf" \
+        copy_with_podman_fallback "$repo_root/conf/relecov_apache_reverse_proxy.conf" \
             "$platform_install_path/conf/relecov_apache_reverse_proxy.conf"
     fi
 fi
@@ -713,17 +731,17 @@ for target_service in "${install_services[@]}"; do
     fi
 
     if [ "$action" = "upgrade" ]; then
-        echo "Running install.sh upgrade in $target_service"
-        engine_exec exec -it "$target_container" bash -c "cd $target_repo_path && bash install.sh --upgrade app --git_revision \"$git_revision\" --conf \"$service_install_conf\" --skip_apache_restart$script_args_before$script_args_after"
+        echo "Running install.sh bootstrap in $target_service (upgrade mode)"
+        engine_exec exec -it "$target_container" bash -c "cd $target_repo_path && bash install.sh --bootstrap upgrade --git_revision \"$git_revision\" --conf \"$service_install_conf\" --skip_apache_restart$script_args_before$script_args_after"
     else
-        echo "Running install.sh install in $target_service"
-        engine_exec exec -it "$target_container" bash -c "cd $target_repo_path && bash install.sh --install app --git_revision \"$git_revision\" --conf \"$service_install_conf\" --skip_apache_restart$script_args_before$script_args_after"
+        echo "Running install.sh bootstrap in $target_service (install mode)"
+        engine_exec exec -it "$target_container" bash -c "cd $target_repo_path && bash install.sh --bootstrap install --git_revision \"$git_revision\" --conf \"$service_install_conf\" --skip_apache_restart$script_args_before$script_args_after"
     fi
 
-    print_container_source_diagnostics "$target_service" "$target_container" "Container diagnostics after install.sh for $target_service:"
+    print_container_source_diagnostics "$target_service" "$target_container" "Container diagnostics after bootstrap for $target_service:"
 
     if ! engine_exec exec -it "$target_container" test -f "$target_install_path/manage.py"; then
-        echo "Error: $target_install_path/manage.py not found after install.sh for service $target_service. Showing logs:"
+        echo "Error: $target_install_path/manage.py not found after bootstrap for service $target_service. Showing logs:"
         engine_exec logs --tail 200 "$target_container"
         exit 1
     fi

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,8 +12,8 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /usr/share/zoneinfo:/usr/share/zoneinfo:ro
-      - /opt/relecov-platform/conf/relecov_apache_reverse_proxy.conf:/etc/httpd/conf.d/relecov.conf:Z,ro
-      - relecov_apache_logs:/var/log/httpd:Z
+      - ${APP_INSTALL_PATH:-/opt/relecov-platform}/conf/relecov_apache_reverse_proxy.conf:/etc/httpd/conf.d/relecov.conf:Z,ro
+      - /var/log/local/apache:/var/log/httpd
       - relecov_static:/opt/relecov-platform/static:z,ro
       - relecov_documents:/opt/relecov-platform/documents:z,ro
       - iskylims_static:/opt/iskylims/static:z,ro
@@ -103,6 +103,5 @@ volumes:
   nextstrain_data:
   relecov_static:
   relecov_documents:
-  relecov_apache_logs:
   iskylims_documents:
   iskylims_static:

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,8 @@ usage : $0 --upgrade --git_revision --conf
     Optional input data:
     --install       | Install relecov-platform full/dep/app
     --upgrade       | Upgrade relecov-platform full/dep/app
+    --stage         | Stage app files only (install/upgrade) without DB work. Internal/container use.
+    --bootstrap     | Run DB/bootstrap steps only (install/upgrade) against an existing staged app. Internal/container use.
     --git_revision  | Git revision name to run (branch, tag, commit SHA, or 'current' to use copied local sources as-is)
     --conf          | Select custom configuration file. Default: ./install_settings.txt
     --tables        | Load the first inital tables (from conf folder)
@@ -34,6 +36,12 @@ Examples:
 
     Upgrade running migration script and update initial tables
     $0 --upgrade full --script <migration_script> --tables
+
+    Stage application files during a container image build
+    $0 --stage install --git_revision main --conf conf/docker_production_settings.txt
+
+    Bootstrap database/static using an already staged container image
+    $0 --bootstrap upgrade --git_revision main --conf conf/docker_production_settings.txt
 
     Make adjustments for apps renaming in upgrade 2.3.0 to 2.3.1
     $0 --upgrade full --ren_app --script <migration_script> --tables
@@ -274,6 +282,20 @@ chown_if_root() {
     fi
 }
 
+detect_apache_group() {
+    if command -v lsb_release >/dev/null 2>&1; then
+        linux_distribution=$(lsb_release -i | cut -f 2-)
+    else
+        linux_distribution=$(awk -F= '/^ID=/{gsub(/"/,""); print $2}' /etc/os-release)
+    fi
+
+    if [[ $linux_distribution == "Ubuntu" || $linux_distribution == "ubuntu" ]]; then
+        apache_group="www-data"
+    else
+        apache_group="apache"
+    fi
+}
+
 ensure_file_exists() {
     local file_path="$1"
     local friendly_name="${2:-$1}"
@@ -332,6 +354,20 @@ check_requirements() {
         root_check
         log_info "Successful checking of root user"
     fi
+}
+
+check_stage_requirements() {
+    log_section "Checking requirements for staged app preparation"
+    python_check
+    log_info "Valid version of Python"
+}
+
+check_bootstrap_requirements() {
+    log_section "Checking requirements for application bootstrap"
+    python_check
+    log_info "Valid version of Python"
+    db_check
+    log_info "Successful check for database"
 }
 
 # install_system_packages: install InterOp and distro-specific OS packages required by relecov-platform.
@@ -446,6 +482,20 @@ run_django_deploy() {
     fi
 }
 
+refresh_static_files() {
+    echo "Deleting static files..."
+    if [ -d "$INSTALL_PATH/static" ]; then
+        if command -v mountpoint >/dev/null 2>&1 && mountpoint -q "$INSTALL_PATH/static"; then
+            echo "Static directory is a mount point. Skipping delete."
+        else
+            rm -rf "$INSTALL_PATH/static" || echo "Skipping static removal (busy)."
+        fi
+    fi
+    echo "Running collect statics..."
+    python manage.py collectstatic --noinput
+    echo "Done collect statics"
+}
+
 # sync_requirements_file: copy repository requirements into the target installation path.
 sync_requirements_file() {
     mkdir -p $INSTALL_PATH/conf
@@ -558,12 +608,7 @@ run_dependency_stage() {
         fi
         install_system_packages
         mkdir -p $INSTALL_PATH
-        linux_distribution=$(lsb_release -i | cut -f 2-)
-        if [[ $linux_distribution == "Ubuntu" ]]; then
-            apache_group="www-data"
-        else
-            apache_group="apache"
-        fi
+        detect_apache_group
         chown_if_root -R "$user:$apache_group" "$INSTALL_PATH"
         chmod 775 $INSTALL_PATH
     else
@@ -581,11 +626,19 @@ run_dependency_stage() {
 
 # upgrade_application_files: sync code/config and run upgrade-specific tasks (renames, migrations).
 upgrade_application_files() {
+    stage_upgrade_application_files
+    bootstrap_application_runtime "upgrade"
+    log_section "Successfuly upgrade of relecov-platform version: ${APP_VERSION}"
+}
+
+# stage_upgrade_application_files: sync code/config into INSTALL_PATH without DB work.
+stage_upgrade_application_files() {
     if [ ! -d $INSTALL_PATH ]; then
         abort_install "Unable to start the upgrade. Folder $INSTALL_PATH does not exist."
     fi
 
     log_section "Starting relecov-platform Upgrade version: ${APP_VERSION}"
+    detect_apache_group
 
     echo "Copying files to installation folder"
     rsync -rlv conf/ $INSTALL_PATH/conf/
@@ -607,41 +660,24 @@ upgrade_application_files() {
     update_settings_and_urls
     prepare_documents_structure
 
-    run_django_deploy "upgrade"
-    echo "Deleting static files..."
-    if [ -d "$INSTALL_PATH/static" ]; then
-        if command -v mountpoint >/dev/null 2>&1 && mountpoint -q "$INSTALL_PATH/static"; then
-            echo "Static directory is a mount point. Skipping delete."
-        else
-            rm -rf "$INSTALL_PATH/static" || echo "Skipping static removal (busy)."
-        fi
-    fi
-    echo "Running collect statics..."
-    python manage.py collectstatic
-    echo "Done collect statics"
-
     cd -
-    log_section "Successfuly upgrade of relecov-platform version: ${APP_VERSION}"
 }
 
 # install_application_files: deploy Django project files, update settings, and run initial migrations.
 install_application_files() {
+    stage_install_application_files
+    bootstrap_application_runtime "install"
+    log_section "Successfuly relecov-platform Installation version: ${APP_VERSION}"
+    echo "Installation completed"
+}
+
+# stage_install_application_files: copy app files into INSTALL_PATH without DB work.
+stage_install_application_files() {
     log_section "Starting relecov-platform install version: ${APP_VERSION}"
 
     user=${SUDO_USER:-$USER}
     group=$(groups | cut -d" " -f1)
-
-    if command -v lsb_release >/dev/null 2>&1; then
-        linux_distribution=$(lsb_release -i | cut -f 2-)
-    else
-        linux_distribution=$(awk -F= '/^ID=/{gsub(/"/,""); print $2}' /etc/os-release)
-    fi
-
-    if [[ $linux_distribution == "Ubuntu" || $linux_distribution == "ubuntu" ]]; then
-        apache_group="www-data"
-    else
-        apache_group="apache"
-    fi
+    detect_apache_group
 
     if [ "$install_type" == "full" ] || [ "$install_type" == "app" ]; then
 
@@ -683,16 +719,31 @@ install_application_files() {
 
         update_settings_and_urls
 
-        run_django_deploy "install"
-
-        echo "Run collectstatic"
-        python manage.py collectstatic
-
         cd -
-
-        log_section "Successfuly relecov-platform Installation version: ${APP_VERSION}"
-        echo "Installation completed"
     fi
+}
+
+# bootstrap_application_runtime: run DB/bootstrap tasks against an already staged INSTALL_PATH.
+bootstrap_application_runtime() {
+    local mode="$1"
+
+    if [ ! -d "$INSTALL_PATH" ]; then
+        abort_install "Unable to bootstrap application. Folder $INSTALL_PATH does not exist."
+    fi
+
+    cd $INSTALL_PATH
+    ensure_virtualenv_ready
+    echo "activate the virtualenv"
+    source virtualenv/bin/activate
+
+    if [ ! -f "$INSTALL_PATH/manage.py" ]; then
+        abort_install "manage.py not found at $INSTALL_PATH/manage.py. Stage application files first."
+    fi
+
+    run_django_deploy "$mode"
+    refresh_static_files
+
+    cd -
 }
 
 # translate long options to short
@@ -707,6 +758,8 @@ do
     # OPTIONAL
         --install)      set -- "$@" -i ;;
         --upgrade)      set -- "$@" -u ;;
+        --stage)        set -- "$@" -j ;;
+        --bootstrap)    set -- "$@" -l ;;
         --script)       set -- "$@" -s ;;
         --script_before) set -- "$@" -p ;;
         --script_after) set -- "$@" -o ;;
@@ -735,6 +788,8 @@ install=true
 install_type="full"
 upgrade=false
 upgrade_type="full"
+workflow="standard"
+workflow_mode=""
 docker=false
 prefilled_tables="conf/first_install_tables.json"
 restart_apache=true
@@ -745,10 +800,11 @@ migration_script_before=()
 skip_tables=false
 
 # PARSE VARIABLE ARGUMENTS WITH getops
-options=":c:s:i:u:r:g:tdbkvhao:p:"
+options=":c:s:i:u:j:l:r:g:tdbkvhao:p:"
 while getopts $options opt; do
     case $opt in
         i ) 
+            workflow="standard"
             install=true
             upgrade=false
             if [[ "$OPTARG" == "full" || "$OPTARG" == "dep" || "$OPTARG" == "app" ]]; then
@@ -760,6 +816,7 @@ while getopts $options opt; do
             fi
             ;;
         u )
+            workflow="standard"
             install=false
             upgrade=true
             if [[ "$OPTARG" == "full" || "$OPTARG" == "dep" || "$OPTARG" == "app" ]]; then
@@ -767,6 +824,22 @@ while getopts $options opt; do
                 install_type=$OPTARG
             else
                 echo "Upgrade is not set to one valid option. Use: --upgrade full/app/dep"
+                exit 1
+            fi
+            ;;
+        j )
+            workflow="stage"
+            workflow_mode=$OPTARG
+            if [[ "$workflow_mode" != "install" && "$workflow_mode" != "upgrade" ]]; then
+                echo "Stage is not set to one valid option. Use: --stage install/upgrade"
+                exit 1
+            fi
+            ;;
+        l )
+            workflow="bootstrap"
+            workflow_mode=$OPTARG
+            if [[ "$workflow_mode" != "install" && "$workflow_mode" != "upgrade" ]]; then
+                echo "Bootstrap is not set to one valid option. Use: --bootstrap install/upgrade"
                 exit 1
             fi
             ;;
@@ -836,6 +909,10 @@ if [ $upgrade == true ]; then
     operation="upgrade"
     operation_scope="$upgrade_type"
 fi
+if [ "$workflow" != "standard" ]; then
+    operation="$workflow_mode"
+    operation_scope="app"
+fi
 
 # Default to loading initial tables on installs unless explicitly skipped.
 if [ "$operation" = "install" ] && [ "$skip_tables" = false ] && [ "$tables" = false ]; then
@@ -846,6 +923,23 @@ load_install_config
 PROJECT_NAME="${PROJECT_NAME:-relecov_platform}"
 checkout_git_revision
 user=${SUDO_USER:-$USER}
+
+if [ "$workflow" = "stage" ]; then
+    check_stage_requirements
+    if [ "$workflow_mode" = "install" ]; then
+        stage_install_application_files
+    else
+        stage_upgrade_application_files
+    fi
+    exit 0
+fi
+
+if [ "$workflow" = "bootstrap" ]; then
+    check_bootstrap_requirements
+    bootstrap_application_runtime "$workflow_mode"
+    exit 0
+fi
+
 check_requirements
 
 if [[ "$operation_scope" == "full" || "$operation_scope" == "dep" ]]; then


### PR DESCRIPTION
This PR updates the container deployment flow so application files are staged into the image at build time, while runtime bootstrap tasks are executed separately when containers start or are upgraded. The goal is to make recreated or restarted containers come up without rerunning the full file installation step.

Main changes:

- Split install.sh into two internal workflows:
--stage: prepares application files only
--bootstrap: runs runtime tasks only, including migrations and collectstatic

- Updated the Dockerfile to run staged app installation during image build.
- Updated container_install.sh to execute install.sh --bootstrap install|upgrade inside containers instead of reinstalling app files.
- Added safer static refresh handling and centralized Apache group detection in install.sh.
- Improved Podman compatibility when copying the Apache reverse proxy config.
- Updated docker-compose.prod.yml to mount Apache config from ${APP_INSTALL_PATH} and persist Apache logs on the host.
- Refreshed README.md and LEAME.md to document the new container behavior and clarify that bare-metal commands remain unchanged.
