### PR TITLE
Fix methodology bioinfo utilization cache generation

### DIFF
--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -72,7 +72,7 @@ def get_bioinfo_analysis_data_from_sample(sample_id):
     return bio_anlys_data
 
 
-def get_bioinfo_analyis_fields_utilization(
+def get_bioinfo_analysis_fields_utilization(
     schema_qs: SchemaLike | None = None,
     *,
     use_cache: bool = True,
@@ -187,13 +187,3 @@ def get_bioinfo_analyis_fields_utilization(
         cache.set(cache_key, result, cache_seconds)
 
     return result
-
-
-def get_bioinfo_analysis_fields_utilization(*args, **kwargs):
-    """Compatibility wrapper with the corrected spelling.
-
-    Some callers use ``analysis`` instead of the historical ``analyis`` typo.
-    Keep both entrypoints valid so preprocessing code can build the cached
-    methodology payload instead of silently falling back to request-time work.
-    """
-    return get_bioinfo_analyis_fields_utilization(*args, **kwargs)

--- a/core/utils/bioinfo_analysis.py
+++ b/core/utils/bioinfo_analysis.py
@@ -187,3 +187,13 @@ def get_bioinfo_analyis_fields_utilization(
         cache.set(cache_key, result, cache_seconds)
 
     return result
+
+
+def get_bioinfo_analysis_fields_utilization(*args, **kwargs):
+    """Compatibility wrapper with the corrected spelling.
+
+    Some callers use ``analysis`` instead of the historical ``analyis`` typo.
+    Keep both entrypoints valid so preprocessing code can build the cached
+    methodology payload instead of silently falling back to request-time work.
+    """
+    return get_bioinfo_analyis_fields_utilization(*args, **kwargs)

--- a/dashboard/utils/met_fields.py
+++ b/dashboard/utils/met_fields.py
@@ -202,7 +202,9 @@ def create_utilization_graphic(lineage):
 
 def schema_fields_utilization():
     """ """
-    schema_fields = core.utils.bioinfo_analysis.get_bioinfo_analyis_fields_utilization()
+    schema_fields = (
+        core.utils.bioinfo_analysis.get_bioinfo_analysis_fields_utilization()
+    )
     for schema_name, fields in schema_fields.items():
         # import pdb; pdb.set_trace()
 

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -71,7 +71,9 @@ def schema_fields_utilization():
     if bio_fields is None:
         result = dashboard.utils.generic_process_data.pre_proc_bioinfo_fields_util()
         if "ERROR" in result:
-            bio_fields = core.utils.bioinfo_analysis.get_bioinfo_analysis_fields_utilization()
+            bio_fields = (
+                core.utils.bioinfo_analysis.get_bioinfo_analysis_fields_utilization()
+            )
         else:
             bio_fields = (
                 _read_cached_bioinfo_util()

--- a/dashboard/utils/met_index.py
+++ b/dashboard/utils/met_index.py
@@ -67,10 +67,16 @@ def schema_fields_utilization():
         util_data["num_lab_fields"] = lims_util.get("num_lab_fields", 0)
 
     # get fields utilization from bioinfo analysis
-    bio_fields = (
-        _read_cached_bioinfo_util()
-        or core.utils.bioinfo_analysis.get_bioinfo_analyis_fields_utilization()
-    )
+    bio_fields = _read_cached_bioinfo_util()
+    if bio_fields is None:
+        result = dashboard.utils.generic_process_data.pre_proc_bioinfo_fields_util()
+        if "ERROR" in result:
+            bio_fields = core.utils.bioinfo_analysis.get_bioinfo_analysis_fields_utilization()
+        else:
+            bio_fields = (
+                _read_cached_bioinfo_util()
+                or core.utils.bioinfo_analysis.get_bioinfo_analysis_fields_utilization()
+            )
     # if return an empty value skip looking for data
     if not bool(bio_fields):
         util_data["ERROR_ANALYSIS"] = "Not Data to process"


### PR DESCRIPTION
## PR Description
This PR fixes the bioinformatics utilization cache flow used by the Methodology index dashboard.

### Problem

`/dashboard/methodology` could become slow on a cold request because the cache entry `methodology_bioinfo_fields` was missing.

Two issues were involved:

- the bioinformatics utilization helper still used a historical typo in its function name
- the Methodology index did not regenerate the missing bioinformatics cache entry when it was absent

As a result, the index could fall back to expensive request-time computation.
