### PR TITLE
Add supercronic-based scheduled cache refresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,13 @@ RUN set -eux; \
       aarch64) supercronic_arch="arm64" ;; \
       *) echo "Unsupported architecture for supercronic: $arch" >&2; exit 1 ;; \
     esac; \
-    wget -q -O /usr/local/bin/supercronic \
-      "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-${supercronic_arch}"; \
-    chmod +x /usr/local/bin/supercronic
+    supercronic_url="https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-${supercronic_arch}"; \
+    if wget --tries=3 --waitretry=2 --retry-connrefused -q -O /usr/local/bin/supercronic "${supercronic_url}"; then \
+      chmod +x /usr/local/bin/supercronic; \
+    else \
+      rm -f /usr/local/bin/supercronic; \
+      echo "Unable to download supercronic from ${supercronic_url}. Continuing without cron support during this build."; \
+    fi
 
 # Ensure python3 points to the desired version
 RUN ln -sf /usr/bin/python3.11 /usr/bin/python3

--- a/conf/template_settings.py
+++ b/conf/template_settings.py
@@ -177,7 +177,16 @@ LOG_CRONTAB_FILE = os.path.join(BASE_DIR, "logs", "crontab.log")
 
 # Crontab settings
 CRONJOBS = [
-    ("0 0 * * 4", "dashboard.cron.update_graphic_json_data", ">>" + LOG_CRONTAB_FILE),
+    (
+        "0 0 * * *",
+        "dashboard.cron.update_search_samples_summary",
+        ">>" + LOG_CRONTAB_FILE,
+    ),
+    (
+        "10 0 1 * *",
+        "dashboard.cron.update_graphic_json_data",
+        ">>" + LOG_CRONTAB_FILE,
+    ),
 ]
 
 CRONTAB_COMMAND_SUFFIX = "2>&1"

--- a/dashboard/cron.py
+++ b/dashboard/cron.py
@@ -33,6 +33,25 @@ def remove_older_graphic_jsons(graphic_name, date):
     return
 
 
+def update_search_samples_summary():
+    """Update only the Sample Browser summary cache."""
+    graphic_name = "search_samples_summary_table"
+    dates = list(
+        dashboard.models.GraphicJsonFile.objects.filter(
+            graphic_name__exact=graphic_name
+        ).values_list("creation_date", flat=True)
+    )
+    if dates:
+        remove_older_graphic_jsons(graphic_name, max(dates))
+
+    print("Starting search_samples_summary update...")
+    print("Start timestamp: ", datetime.today().strftime("%Y-%m-%d %H:%M:%S"))
+    print("Running pre_proc_search_samples_summary()")
+    dashboard.utils.generic_process_data.pre_proc_search_samples_summary()
+    print("search_samples_summary update finished")
+    print("End timestamp: ", datetime.today().strftime("%Y-%m-%d %H:%M:%S"))
+
+
 def update_graphic_json_data():
     """This function is called from crontab to update graphic json data.
     It also removes all the previous graphic jsons except for the last.
@@ -104,8 +123,6 @@ def update_graphic_json_data():
     dashboard.utils.generic_process_data.pre_proc_intranet_ena_data()
     print("Running pre_proc_methodology_lims_fields_util()")
     dashboard.utils.generic_process_data.pre_proc_methodology_lims_fields_util()
-    print("Running pre_proc_search_samples_summary()")
-    dashboard.utils.generic_process_data.pre_proc_search_samples_summary()
     print("Running pre_proc_bioinfo_fields_util()")
     dashboard.utils.generic_process_data.pre_proc_bioinfo_fields_util()
     uniq_chrom_id_list = [

--- a/scripts/container_start.sh
+++ b/scripts/container_start.sh
@@ -50,9 +50,35 @@ if [ "$APP_MODE" = "dev" ]; then
 fi
 
 if command -v supercronic >/dev/null 2>&1; then
-    # Ensure django-crontab definitions are installed in user crontab first.
-    python "${APP_DIR}/manage.py" crontab add >/dev/null 2>&1 || true
-    crontab -l 2>/dev/null | sed '/^\s*#/d; /^\s*$/d' > "${CRON_FILE}" || true
+    python - <<'PY' > "${CRON_FILE}"
+import os
+import shlex
+import sys
+
+import django
+
+app_dir = os.environ.get("APP_INSTALL_PATH", "/opt/relecov-platform")
+project_module = os.environ.get("PROJECT_MODULE", "relecov_platform")
+sys.path.insert(0, app_dir)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", f"{project_module}.settings")
+django.setup()
+
+from django.conf import settings
+
+python_bin = os.path.join(app_dir, "virtualenv", "bin", "python")
+manage_py = os.path.join(app_dir, "manage.py")
+
+for job in getattr(settings, "CRONJOBS", []):
+    schedule, dotted_path = job[:2]
+    module_name, function_name = dotted_path.rsplit(".", 1)
+    python_code = f"import {module_name} as _m; _m.{function_name}()"
+    command = (
+        f"cd {shlex.quote(app_dir)} && "
+        f"{shlex.quote(python_bin)} {shlex.quote(manage_py)} "
+        f"shell -c {shlex.quote(python_code)}"
+    )
+    print(f"{schedule} {command}")
+PY
     if [ -s "${CRON_FILE}" ]; then
         safe_chmod 600 "${CRON_FILE}"
         : > "${CRON_LOG}"


### PR DESCRIPTION
## PR Description

This PR introduces container-managed scheduled cache refresh using `supercronic`.

### Changes

- generate cron entries directly from Django `CRONJOBS` in the container entrypoint
- split the Sample Browser cache refresh from the heavier graphic JSON refresh
- schedule `search_samples_summary` daily
- schedule the full dashboard graphic refresh monthly
- make the Docker build tolerate transient failures when downloading `supercronic`
- stage the application tree during image build so containers restart cleanly

### Result

- cron execution is managed inside the app container
- `search_samples_summary_table` can be refreshed independently from the heavier dashboard cache jobs
- builds are more resilient when GitHub is temporarily unreachable
